### PR TITLE
[OSDEV-1812] Smoke: Moderation queue page is can be opened through the Dashboard by a Moderation manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 .env
+/tests/downloads/

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -46,7 +46,7 @@ test("OSDEV-1235: Smoke: Django Admin Panel. Log-in with valid credentials", asy
   page,
 }) => {
   const { BASE_URL } = process.env;
-  await page.goto(BASE_URL + "/admin/"!);
+  await page.goto(`${BASE_URL}/admin/`);
 
   // make sure that we are on the login page of Admin Dashboard
   const title = await page.title();
@@ -54,9 +54,9 @@ test("OSDEV-1235: Smoke: Django Admin Panel. Log-in with valid credentials", asy
   await expect(page.getByText("Open Supply Hub Admin")).toBeVisible();
 
   // fill in login credentials
-  const { USER_EMAIL, USER_PASSWORD } = process.env;
-  await page.getByLabel("Email").fill(USER_EMAIL!);
-  await page.getByLabel("Password").fill(USER_PASSWORD!);
+  const { USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD } = process.env;
+  await page.getByLabel("Email").fill(USER_ADMIN_EMAIL!);
+  await page.getByLabel("Password").fill(USER_ADMIN_PASSWORD!);
   await page.getByRole("button", { name: "Log In" }).click();
 
   // make sure that we have successfully logged in
@@ -82,7 +82,9 @@ test("OSDEV-1235: Smoke: Django Admin Panel. Log-in with valid credentials", asy
 
   // log the user out and make sure we are logged out
   await page.getByRole("link", { name: "Log out" }).click();
-  await expect(page.getByText(`Welcome, ${USER_EMAIL}`)).not.toBeVisible();
+  await expect(
+    page.getByText(`Welcome, ${USER_ADMIN_EMAIL}`)
+  ).not.toBeVisible();
   await expect(page.getByText("Log in again")).toBeVisible();
 });
 
@@ -1259,15 +1261,19 @@ test.describe("OSDEV-1812: Smoke: Moderation queue page is can be opened through
       })
       .click();
     await expect(page.getByRole("heading", { name: "Log In" })).toBeVisible();
+    await page.waitForLoadState("networkidle");
 
     // fill in login with regular user credentials
     const { USER_EMAIL, USER_PASSWORD } = process.env;
     await page.getByLabel("Email").fill(USER_EMAIL!);
     await page.getByRole("textbox", { name: "Password" }).fill(USER_PASSWORD!);
     await page.getByRole("button", { name: "Log In" }).click();
-    await page.waitForLoadState("networkidle");
+    const resp = await page.waitForResponse(async (resp) =>
+      resp.url().includes("/user-login/")
+    );
+    expect(resp.status()).toBe(200);
 
-    await page.goto(`${BASE_URL}/dashboard/moderation-queue/`!);
+    await page.goto(`${BASE_URL}/dashboard/moderation-queue/`);
     await expect(
       page.getByRole("heading", { name: "Not found" })
     ).toBeVisible();

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1241,4 +1241,40 @@ test.describe("OSDEV-1812: Smoke: Moderation queue page is can be opened through
       })
     ).toBeVisible();
   });
+
+  test("A regular user does not have an access to the Moderation Queue page.", async ({
+    page,
+  }) => {
+    const { BASE_URL } = process.env;
+    await page.goto(`${BASE_URL}/dashboard/moderation-queue/`!);
+    await page.waitForLoadState("networkidle");
+
+    // make sure that we can not open the Moderation queue page of Dashboard without authorization
+    await expect(
+      page.getByRole("heading", { name: "Dashboard" })
+    ).toBeVisible();
+    await page
+      .getByRole("link", {
+        name: "Sign in to view your Open Supply Hub Dashboard",
+      })
+      .click();
+    await expect(page.getByRole("heading", { name: "Log In" })).toBeVisible();
+
+    // fill in login with regular user credentials
+    const { USER_EMAIL, USER_PASSWORD } = process.env;
+    await page.getByLabel("Email").fill(USER_EMAIL!);
+    await page.getByRole("textbox", { name: "Password" }).fill(USER_PASSWORD!);
+    await page.getByRole("button", { name: "Log In" }).click();
+    await page.waitForLoadState("networkidle");
+
+    await page.goto(`${BASE_URL}/dashboard/moderation-queue/`!);
+    await expect(
+      page.getByRole("heading", { name: "Not found" })
+    ).toBeVisible();
+    await expect(
+      page
+        .getByRole("heading", { name: "Dashboard / Moderation Queue" })
+        .getByRole("link")
+    ).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
[OSDEV-1812] Smoke: The moderation queue page can be opened through the Dashboard by a Moderation manager.
 [task OSDEV-1972](https://opensupplyhub.atlassian.net/browse/OSDEV-1972)

Steps:
1. Only the data moderator has access
2. The Moderation Queue link is available in the Dashboard
3. The Moderation Queue page is opened successfully
4. Moderation events can be filtered (Data Source, Moderation Status, Country,  date filter)
5. Pagination 25/50is available
6. A Data Moderator can download data from the active page
7.  Moderation events can be opened

This PR is only an update to the work done by @Innavin369 in https://github.com/opensupplyhub/open-supply-hub-e2e-tests/pull/7 and contains mostly the same code and PR description.