### PR TITLE
New tests for the facility page v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ VERSION_TAG={version_tag}
   ```
 
 - **Tags** (embedded in test titles; filter with Playwright’s `--grep`):
-  - **`@smokev1`** / **`@smokev2`** — two smoke test suites that support running tests for both the old and new location page UI
+  - **`@smokev1`** / **`@smokev2`** — two smoke test suites that support running tests for both the old (v1) and new (v2) location page UI. 
   - **`@regression`** — regression scenarios that can be executed during regression testing in a pre-production environment to reduce testing time and increase test coverage
-  
+
   Examples:
 
   ```bash
-  # Smoke v1
+  # Smoke v1. Run it when enable_production_location_page is off
   npx playwright test --grep "@smokev1"
 
-  # Smoke v2
+  # Smoke v2. Run it when enable_production_location_page is on
   npx playwright test --grep "@smokev2"
 
-  # Regression only
+  # Regression
   npx playwright test --grep "@regression"
 
   # Full suite (smoke + regression + everything else)

--- a/README.md
+++ b/README.md
@@ -43,10 +43,25 @@ VERSION_TAG={version_tag}
   npm run test
   ```
 
-- Run only "smoke" tests:
-  npx playwright test --grep "@smoke"
+- **Tags** (embedded in test titles; filter with Playwright’s `--grep`):
+  - **`@smokev1`** / **`@smokev2`** — two smoke test suites that support running tests for both the old and new location page UI
+  - **`@regression`** — regression scenarios that can be executed during regression testing in a pre-production environment to reduce testing time and increase test coverage
+  
+  Examples:
 
-- Run without any tags to run all tests during regression testing.
+  ```bash
+  # Smoke v1
+  npx playwright test --grep "@smokev1"
+
+  # Smoke v2
+  npx playwright test --grep "@smokev2"
+
+  # Regression only
+  npx playwright test --grep "@regression"
+
+  # Full suite (smoke + regression + everything else)
+  npm run test
+  ```
 
 ### Option 2: Docker Setup (Recommended)
 
@@ -78,8 +93,10 @@ This project includes Docker configuration for easy setup and consistent testing
    # Run all tests
    docker-compose exec e2e-tests npm run test
 
-   # Run smoke tests
-   docker-compose exec e2e-tests npx playwright test --grep "@smoke"
+   # Run smoke by tag (same as locally)
+   docker-compose exec e2e-tests npx playwright test --grep "@smokev1"
+   docker-compose exec e2e-tests npx playwright test --grep "@smokev2"
+   docker-compose exec e2e-tests npx playwright test --grep "@regression"
    ```
 
 4. **Access test reports:**

--- a/tests/admin-wage-indicator-country-data.spec.ts
+++ b/tests/admin-wage-indicator-country-data.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, Page } from "@playwright/test";
+import { setup } from "./utils/env";
+import { LoginPage } from "./pages/LoginPage";
+
+test.beforeAll(setup);
+
+const WAGE_COLUMN_HEADERS = [
+  "Living wage link national",
+  "Minimum wage link english",
+  "Minimum wage link national",
+] as const;
+
+
+async function findColumnIndexByHeader(page: Page, headerSubstring: string): Promise<number> {
+  return page.evaluate((label) => {
+    const normalized = label.toLowerCase();
+    const table = document.querySelector("#result_list");
+    if (!table) return -1;
+    const headerCells = [...table.querySelectorAll("thead th")];
+    return headerCells.findIndex((th) =>
+      (th.textContent || "").toLowerCase().includes(normalized)
+    );
+  }, headerSubstring);
+}
+
+
+async function collectLinksFromColumnByHeader(
+  page: Page,
+  baseUrl: string,
+  headerLabel: string
+): Promise<string[]> {
+  const idx = await findColumnIndexByHeader(page, headerLabel);
+  expect(idx, `Column "${headerLabel}" not found in #result_list`).toBeGreaterThanOrEqual(0);
+
+  const hrefs = await page.evaluate(
+    ({ columnIndex }: { columnIndex: number }) => {
+      const table = document.querySelector("#result_list");
+      if (!table) return [] as string[];
+      const rows = [...table.querySelectorAll("tbody tr")];
+      const out: string[] = [];
+      for (const row of rows) {
+        const cells = row.querySelectorAll("td");
+        const cell = cells[columnIndex];
+        if (!cell) continue;
+        for (const a of cell.querySelectorAll("a[href]")) {
+          const href = a.getAttribute("href");
+          if (href) out.push(href);
+        }
+      }
+      return out;
+    },
+    { columnIndex: idx }
+  );
+
+  return [...new Set(hrefs.map((h) => new URL(h, baseUrl).href))];
+}
+
+type UrlCheckFailure = { url: string; detail: string };
+
+function formatUrlFailures(failures: UrlCheckFailure[]): string {
+  return failures.map((f) => `  ${f.url}\n    → ${f.detail}`).join("\n");
+}
+
+
+async function collectNon200Responses(
+  page: Page,
+  urls: string[],
+  chunkSize = 15
+): Promise<UrlCheckFailure[]> {
+  const failures: UrlCheckFailure[] = [];
+
+  for (let i = 0; i < urls.length; i += chunkSize) {
+    const chunk = urls.slice(i, i + chunkSize);
+    const results = await Promise.all(
+      chunk.map(async (url) => {
+        try {
+          const response = await page.request.get(url);
+          const status = response.status();
+          return { url, ok: status === 200, detail: `HTTP ${status}` };
+        } catch (e) {
+          const detail = e instanceof Error ? e.message : String(e);
+          return { url, ok: false, detail };
+        }
+      })
+    );
+
+    for (const r of results) {
+      if (!r.ok) {
+        failures.push({ url: r.url, detail: r.detail });
+      }
+    }
+  }
+
+  return failures;
+}
+
+function assertNoBadUrls(failures: UrlCheckFailure[]): void {
+  if (failures.length === 0) {
+    return;
+  }
+  throw new Error(
+    `Expected HTTP 200 for all links. Failed (${failures.length}):\n${formatUrlFailures(failures)}`
+  );
+}
+
+async function loginAndOpenWageIndicatorList(page: Page, baseUrl: string): Promise<void> {
+  const { USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD } = process.env;
+  const loginPage = new LoginPage(page, baseUrl);
+  await loginPage.loginToAdminPanel(USER_ADMIN_EMAIL!, USER_ADMIN_PASSWORD!);
+
+  await page.goto(`${baseUrl}/admin/api/wageindicatorcountrydata/?all=`);
+  await page.waitForLoadState("networkidle");
+  await expect(page.locator("#result_list")).toBeVisible();
+}
+
+
+
+
+
+test.describe("[@regression] Admin: Wage Indicator Country Data", () => {
+  test("Wage column links (Living wage link national, Minimum wage link english, Minimum wage link national) return HTTP 200", async ({
+    page,
+  }) => {
+    const { BASE_URL } = process.env;
+
+    await loginAndOpenWageIndicatorList(page, BASE_URL!);
+
+    const hrefs = new Set<string>();
+    for (const header of WAGE_COLUMN_HEADERS) {
+      const columnUrls = await collectLinksFromColumnByHeader(page, BASE_URL!, header);
+      for (const u of columnUrls) {
+        hrefs.add(u);
+      }
+    }
+
+    expect(
+      hrefs.size,
+      "Expected at least one link in the wage column cells to verify"
+    ).toBeGreaterThan(0);
+
+    const failures = await collectNon200Responses(page, [...hrefs]);
+    assertNoBadUrls(failures);
+  });
+});

--- a/tests/api-smoke.spec.ts
+++ b/tests/api-smoke.spec.ts
@@ -24,7 +24,7 @@ test.beforeAll(setup);
 
 test.describe("OSDEV-1233: Smoke Tests - API Facilities Search", () => {
   test.describe("Get list of facilities from `/facilities/` endpoint", () => {
-    test("[@smoke] GET `/facilities/`", async ({ request }) => {
+    test("[@smokev1][@smokev2] GET `/facilities/`", async ({ request }) => {
       const response = await get(request, "/api/facilities/", {
         authenticate: true,
       });
@@ -34,7 +34,7 @@ test.describe("OSDEV-1233: Smoke Tests - API Facilities Search", () => {
       validate(facilitiesSchema, body);
     });
 
-    test("[@smoke] Get list of facilities from `/facilities/?details=true` endpoint`", async ({
+    test("[@smokev1][@smokev2] Get list of facilities from `/facilities/?details=true` endpoint`", async ({
       request,
     }) => {
       const response = await get(request, "/api/facilities/?detail=true", {
@@ -46,7 +46,7 @@ test.describe("OSDEV-1233: Smoke Tests - API Facilities Search", () => {
       validate(facilitiesSchemaDetailsTrue, body);
     });
 
-    test("[@smoke] GET `/facilities/` unauthorized", async ({ request }) => {
+    test("[@smokev1][@smokev2] GET `/facilities/` unauthorized", async ({ request }) => {
       const response = await get(request, "/api/facilities/", {
         authenticate: false,
       });
@@ -58,7 +58,7 @@ test.describe("OSDEV-1233: Smoke Tests - API Facilities Search", () => {
   });
 
   test.describe("Get list of facilities from `/facilities/downloads` endpoint", () => {
-    test("[@smoke] GET `/facilities-downloads/` unauthorized", async ({ request }) => {
+    test("[@smokev1][@smokev2] GET `/facilities-downloads/` unauthorized", async ({ request }) => {
       const response = await get(request, "/api/facilities-downloads/", {
         authenticate: false,
       });
@@ -68,7 +68,7 @@ test.describe("OSDEV-1233: Smoke Tests - API Facilities Search", () => {
       validate(unauthorizedSchema, body);
     });
 
-    test("[@smoke] GET `/facilities-downloads/` authenticated", async ({ request }) => {
+    test("[@smokev1][@smokev2] GET `/facilities-downloads/` authenticated", async ({ request }) => {
       const response = await get(request, "/api/facilities-downloads/", {
         authenticate: true,
       });
@@ -81,7 +81,7 @@ test.describe("OSDEV-1233: Smoke Tests - API Facilities Search", () => {
 });
 
 // new part of the tests. coves get requests for https://opensupplyhub.org/api/docs/#!/facilities
-test("[@smoke] GET `/claim-statuses/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/claim-statuses/`", async ({ request }) => {
   const response = await get(request, "/api/claim-statuses/", {
     authenticate: true,
   });
@@ -92,7 +92,7 @@ test("[@smoke] GET `/claim-statuses/`", async ({ request }) => {
   expect(body).toEqual(expect.arrayContaining(claimStatuses));
 });
 
-test("[@smoke] 401 GET `/claim-statuses/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/claim-statuses/`", async ({ request }) => {
   const response = await get(request, "/api/claim-statuses/", {
     authenticate: false,
   });
@@ -103,7 +103,7 @@ test("[@smoke] 401 GET `/claim-statuses/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/contributor-types/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/contributor-types/`", async ({ request }) => {
   const response = await get(request, "/api/contributor-types/", {
     authenticate: true,
   });
@@ -114,7 +114,7 @@ test("[@smoke] GET `/contributor-types/`", async ({ request }) => {
   expect(body).toEqual(expect.arrayContaining(contributorTypes));
 });
 
-test("[@smoke] 401 GET `/contributor-types/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/contributor-types/`", async ({ request }) => {
   const response = await get(request, "/api/contributor-types/", {
     authenticate: false,
   });
@@ -125,7 +125,7 @@ test("[@smoke] 401 GET `/contributor-types/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/countries/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/countries/`", async ({ request }) => {
   const response = await get(request, "/api/countries/", {
     authenticate: true,
   });
@@ -141,7 +141,7 @@ test("[@smoke] GET `/countries/`", async ({ request }) => {
   }
 });
 
-test("[@smoke] 401 GET `/countries/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/countries/`", async ({ request }) => {
   const response = await get(request, "/api/countries/", {
     authenticate: false,
   });
@@ -152,7 +152,7 @@ test("[@smoke] 401 GET `/countries/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/facilities/count/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/facilities/count/`", async ({ request }) => {
   const response = await get(request, "/api/facilities/count/", {
     authenticate: true,
   });
@@ -163,7 +163,7 @@ test("[@smoke] GET `/facilities/count/`", async ({ request }) => {
   validate(facilitiesCount, body);
 });
 
-test("[@smoke] 401 GET `/facilities/count/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/facilities/count/`", async ({ request }) => {
   const response = await get(request, "/api/facilities/count/", {
     authenticate: false,
   });
@@ -174,7 +174,7 @@ test("[@smoke] 401 GET `/facilities/count/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] 401 GET `/facilities/BD20190853EMPB5/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/facilities/BD20190853EMPB5/`", async ({ request }) => {
   const response = await get(request, "/api/facilities/BD20190853EMPB5/", {
     authenticate: false,
   });
@@ -185,7 +185,7 @@ test("[@smoke] 401 GET `/facilities/BD20190853EMPB5/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/facilities/{os_id}` using first result from `/facilities/`", async ({
+test("[@smokev1][@smokev2] GET `/facilities/{os_id}` using first result from `/facilities/`", async ({
   request,
 }) => {
   // Step 1: Get list of facilities
@@ -213,7 +213,7 @@ test("[@smoke] GET `/facilities/{os_id}` using first result from `/facilities/`"
   validate(facilitiesById, detailBody); // schema validation for detailed view
 });
 
-test("[@smoke] GET `/facility-processing-types/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/facility-processing-types/`", async ({ request }) => {
   const response = await get(request, "/api/facility-processing-types/", {
     authenticate: true,
   });
@@ -224,7 +224,7 @@ test("[@smoke] GET `/facility-processing-types/`", async ({ request }) => {
   validate(facilityProcessingTypes, body);
 });
 
-test("[@smoke] 401 GET `/facility-processing-types/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/facility-processing-types/`", async ({ request }) => {
   const response = await get(request, "/api/facility-processing-types/", {
     authenticate: false,
   });
@@ -235,7 +235,7 @@ test("[@smoke] 401 GET `/facility-processing-types/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/moderation-events/merge/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/moderation-events/merge/`", async ({ request }) => {
   const response = await get(request, "/api/moderation-events/merge/", {
     authenticate: true,
   });
@@ -246,7 +246,7 @@ test("[@smoke] GET `/moderation-events/merge/`", async ({ request }) => {
   validate(moderationEventsMerge, body);
 });
 
-test("[@smoke] 401 GET `/moderation-events/merge/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/moderation-events/merge/`", async ({ request }) => {
   const response = await get(request, "/api/moderation-events/merge/", {
     authenticate: false,
   });
@@ -257,7 +257,7 @@ test("[@smoke] 401 GET `/moderation-events/merge/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/parent-companies/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/parent-companies/`", async ({ request }) => {
   const response = await get(request, "/api/parent-companies/", {
     authenticate: true,
   });
@@ -268,7 +268,7 @@ test("[@smoke] GET `/parent-companies/`", async ({ request }) => {
   validate(parentCompanies, body);
 });
 
-test("[@smoke] 401 GET `/parent-companies/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/parent-companies/`", async ({ request }) => {
   const response = await get(request, "/api/parent-companies/", {
     authenticate: false,
   });
@@ -279,7 +279,7 @@ test("[@smoke] 401 GET `/parent-companies/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/product-types/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/product-types/`", async ({ request }) => {
   const response = await get(request, "/api/product-types/", {
     authenticate: true,
   });
@@ -290,7 +290,7 @@ test("[@smoke] GET `/product-types/`", async ({ request }) => {
   validate(productTypes, body);
 });
 
-test("[@smoke] 401 GET `/product-types/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/product-types/`", async ({ request }) => {
   const response = await get(request, "/api/product-types/", {
     authenticate: false,
   });
@@ -301,7 +301,7 @@ test("[@smoke] 401 GET `/product-types/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/sectors/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/sectors/`", async ({ request }) => {
   const response = await get(request, "/api/sectors/", {
     authenticate: true,
   });
@@ -312,7 +312,7 @@ test("[@smoke] GET `/sectors/`", async ({ request }) => {
   validate(sectors, body);
 });
 
-test("[@smoke] 401 GET `/sectors/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/sectors/`", async ({ request }) => {
   const response = await get(request, "/api/sectors/", {
     authenticate: false,
   });
@@ -323,7 +323,7 @@ test("[@smoke] 401 GET `/sectors/`", async ({ request }) => {
   validate(unauthorizedSchema, body);
 });
 
-test("[@smoke] GET `/workers-ranges/`", async ({ request }) => {
+test("[@smokev1][@smokev2] GET `/workers-ranges/`", async ({ request }) => {
   const response = await get(request, "/api/workers-ranges/", {
     authenticate: true,
   });
@@ -334,7 +334,7 @@ test("[@smoke] GET `/workers-ranges/`", async ({ request }) => {
   validate(workersRanges, body);
 });
 
-test("[@smoke] 401 GET `/workers-ranges/`", async ({ request }) => {
+test("[@smokev1][@smokev2] 401 GET `/workers-ranges/`", async ({ request }) => {
   const response = await get(request, "/api/workers-ranges/", {
     authenticate: false,
   });

--- a/tests/moderation-queue.spec.ts
+++ b/tests/moderation-queue.spec.ts
@@ -5,8 +5,8 @@ import { AdminDashboardPage } from "./pages/AdminDashboardPage";
 
 test.beforeAll(setup);
 
-test.describe("[@Regression] OSDEV-2195 Moderation Queue - Authentication and Access", () => {
-  test("[@Regression] OSDEV-2195-1: Verify regular user sees 'Not found' after authentication", async ({ page }) => {
+test.describe("[@regression] OSDEV-2195 Moderation Queue - Authentication and Access", () => {
+  test("[@regression] OSDEV-2195-1: Verify regular user sees 'Not found' after authentication", async ({ page }) => {
     const { BASE_URL, USER_EMAIL, USER_PASSWORD } = process.env;
     
     const loginPage = new LoginPage(page, BASE_URL!);
@@ -22,7 +22,7 @@ test.describe("[@Regression] OSDEV-2195 Moderation Queue - Authentication and Ac
     await adminDashboardPage.expectNotFoundHeading();
   });
 
-  test("[@Regression] OSDEV-2195-2: Verify admin user can access moderation queue", async ({ page }) => {
+  test("[@regression] OSDEV-2195-2: Verify admin user can access moderation queue", async ({ page }) => {
     const { BASE_URL, USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD } = process.env;
     
     const loginPage = new LoginPage(page, BASE_URL!);
@@ -41,7 +41,7 @@ test.describe("[@Regression] OSDEV-2195 Moderation Queue - Authentication and Ac
     expect(headingText).toContain("Moderation Queue");
   });
 
-  test("[@Regression] OSDEV-2195-3: Verify admin can directly access moderation queue via main page login", async ({ page }) => {
+  test("[@regression] OSDEV-2195-3: Verify admin can directly access moderation queue via main page login", async ({ page }) => {
     const { BASE_URL, USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD } = process.env;
     
     const loginPage = new LoginPage(page, BASE_URL!);
@@ -55,7 +55,7 @@ test.describe("[@Regression] OSDEV-2195 Moderation Queue - Authentication and Ac
     expect(headingText).toContain("Moderation Queue");
   });
 
-  test("[@Regression] OSDEV-2195-4: Verify regular user sees 'Not found' when accessing via main page login", async ({ page }) => {
+  test("[@regression] OSDEV-2195-4: Verify regular user sees 'Not found' when accessing via main page login", async ({ page }) => {
     const { BASE_URL, USER_EMAIL, USER_PASSWORD } = process.env;
     
     const loginPage = new LoginPage(page, BASE_URL!);

--- a/tests/pages/LoginPage.ts
+++ b/tests/pages/LoginPage.ts
@@ -68,7 +68,7 @@ export class LoginPage extends BasePage {
     await this.myAccountButton().click();
     await this.settingsLink().click();
     await this.page.isVisible(`text=${email}`);
-    await this.myAccountButton().click();
+
   }
 
   // Admin panel authentication methods

--- a/tests/pages/MainPage.ts
+++ b/tests/pages/MainPage.ts
@@ -14,7 +14,10 @@ export class MainPage extends BasePage {
   private loginButton = () => this.page.getByRole("button", { name: "LOG IN" });
   private noFacilitiesMessage = () => this.page.getByText("No facilities matching this");
   private contributorsText = () => this.page.getByText("# Contributors");
-  private facilityLinks = () => this.page.locator('a[href*="/facilities/"]');
+  private facilityLinks = () =>
+    this.page.locator(
+      'a[href*="/facilities/"], a[href*="/production-locations/"]'
+    );
   private resultsText = () => this.page.getByText(/^\d+ results$/);
 
   // Filter dropdowns
@@ -126,6 +129,14 @@ export class MainPage extends BasePage {
   async getResultsCount(): Promise<number> {
     const text = await this.resultsText().textContent();
     return parseInt(text?.match(/\d+/)?.[0] || "0", 10);
+  }
+
+  async getOSIDFromLocationPage(): Promise<string> {
+    const osIdHeading = this.page.getByTestId("os-id");
+    await this.expectToBeVisible(osIdHeading);
+    const text = (await osIdHeading.textContent()) ?? "";
+    const match = text.match(/OS ID:\s*(\S+)/i);
+    return (match?.[1] ?? text).trim();
   }
 
   async getOSIDFromFacilityPage(): Promise<string> {

--- a/tests/pages/README.md
+++ b/tests/pages/README.md
@@ -9,74 +9,68 @@ tests/pages/
 ├── BasePage.ts          # Base class with common functionality
 ├── LoginPage.ts         # Authentication for main page and admin panel
 ├── MainPage.ts          # Main page functionality (search, navigation, downloads)
-├── AdminPage.ts         # Admin panel functionality
+├── AdminPage.ts         # Django admin contributor/download-limit operations
+├── AdminDashboardPage.ts  # Dashboard moderation queue access and assertions
 └── README.md           # This documentation
 ```
 
 ## Page Objects
 
 ### BasePage
-The foundation class that provides common functionality for all page objects:
-- Navigation methods (`goto`, `waitForLoadState`)
-- Common interactions (`clickButton`, `clickLink`, `fillInput`)
-- Assertion helpers (`expectToBeVisible`, `expectToHaveText`, `expectToHaveValue`)
+Base class extended by all page objects.
+
+- Navigation: (`goTo`, `getCurrentUrl()`)
+- Wait helpers: (`waitForLoadState`, `waitForResponse`)
+- Common interactions: (`clickButton`, `clickLink`, `fillInput`)
+- Assertion helpers: (`expectToBeVisible`, `expectToHaveText`, `expectToHaveValue`)
 
 ### LoginPage
-Handles authentication for both the main application and admin panel:
-- `loginToMainPage(email, password)` - Login to main application
-- `logoutFromMainPage()` - Logout from main application
-- `loginToAdminPanel(email, password)` - Login to Django admin
-- `logoutFromAdminPanel()` - Logout from admin panel
-- `verifyMainPageLogin(email)` - Verify successful main page login
-- `verifyAdminPanelLogin(email)` - Verify successful admin login
+Authentication flows for both the main app and Django admin.
+
+- Main app: `loginToMainPage`, `completeLoginForm`, `logoutFromMainPage`, `verifyMainPageLogin`, `isLoggedIn`
+- Admin app: `loginToAdminPanel`, `logoutFromAdminPanel`, `verifyAdminPanelLogin`, `isAdminLoggedIn`
+- Utility: `getPageTitle`
 
 ### MainPage
-Manages main page functionality including search and navigation:
-- `goto()` - Navigate to main page and verify title
-- `searchFacilities(query)` - Search for facilities by name
-- `searchByOSID(osId)` - Search by OS ID
-- `searchByCountry(country)` - Filter by country
-- `searchByFacilityType(type)` - Filter by facility type
-- `searchByWorkerRange(range)` - Filter by worker range
-- `clickFirstFacility()` - Click first facility in results
-- `downloadFacilitiesExcel()` - Download facilities as Excel
-- Various expectation methods for search results
+Public main-site search and results behavior.
+
+- Navigation/title: `goTo`, `verifyPageTitle`
+- Search and filters: `searchFacilities`, `searchByOSID`, `searchByCountry`, `searchByFacilityType`, `searchByWorkerRange`, `performSearch`
+- Results actions: `clickFirstFacility`, `goBackToSearchResults`, `downloadFacilitiesExcel`
+- Assertions: `expectSearchResults`, `expectNoFacilitiesMessage`, `expectFacilityInResults`, `expectOSIDInResults`, `expectCountryInResults`, `expectDownloadLoginPrompt`
+- Data helpers: `getResultsCount`, `getOSIDFromLocationPage`, `getOSIDFromFacilityPage`
 
 ### AdminPage
-Handles Django admin panel functionality:
-- `gotoContributors()` - Navigate to contributors admin page
-- `searchContributor(email)` - Search for a specific contributor
-- `clickFirstContributor()` - Click first contributor in results
-- `clearEmbedConfiguration()` - Clear embed settings
-- `setEmbedLevelToDeluxe()` - Set embed level to deluxe
-- `saveChanges()` - Save admin changes
-- Various verification methods
+Django admin flows for contributors and download limits.
 
+- Contributor flow: `goToContributors`, `searchContributor`, `clickFirstContributor`, `expectChangeContributorPage`, `expectAdminEmail`
+- Embed config flow: `clearEmbedConfiguration`, `setEmbedLevel`, `setEmbedLevelToDeluxe`, `saveChanges`, `expectEmbedConfigCreated`, `getEmbedConfigValue`, `expectSuccessMessageForContributor`
+- Download-limit flow: `goToDownloadLimits`, `expectDownloadLimitsPage`, `searchUserDownloadLimit`, `clickFirstRowLinkDownloadLimit`, `expectChangeDownloadLimitHeading`, `setFreeDownloadRecords`, `expectSuccessMessageForDownloadLimit`
 
+### AdminDashboardPage
+Dashboard moderation-queue navigation and access assertions.
+
+- Navigation: `goToModerationQueue`
+- Access/state checks: `expectSignInLinkVisible`, `clickSignInLink`, `isAuthenticationRequired`
+- Queue/not-found assertions: `expectModerationQueueHeading`, `expectModerationQueuePage`, `expectNotFoundHeading`
+- Utility: `getPageHeading`, `isOnModerationQueuePage`
 
 ## Usage Example
 
 ```typescript
-import { LoginPage, MainPage } from "./pages/LoginPage";
-import { MainPage } from "./pages/MainPage";
+import { test } from "@playwright/test";
+import { LoginPage } from "./LoginPage";
+import { MainPage } from "./MainPage";
 
 test("Example test using page objects", async ({ page }) => {
   const { BASE_URL, USER_EMAIL, USER_PASSWORD } = process.env;
-  
+
   const loginPage = new LoginPage(page, BASE_URL!);
   const mainPage = new MainPage(page, BASE_URL!);
 
-  // Navigate and login
-  await mainPage.goto();
-  await mainPage.verifyPageTitle();
   await loginPage.loginToMainPage(USER_EMAIL!, USER_PASSWORD!);
-
-  // Perform search
   await mainPage.searchFacilities("Test Facility");
   await mainPage.expectSearchResults();
-
-  // Verify results
-  await mainPage.clickFirstFacility();
   await mainPage.expectFacilityInResults("Test Facility");
 });
 ```
@@ -113,4 +107,4 @@ The existing tests have been refactored to use page objects where appropriate. K
 - Encapsulated login logic in `LoginPage`
 - Centralized search and download functionality in `MainPage`
 - Moved admin operations to `AdminPage`
-- Some tests (like OSDEV-1232) continue to use direct Playwright code for specific requirements 
+- Some tests (like OSDEV-1232) continue to use direct Playwright code for specific requirements

--- a/tests/schemas/facilities-by-id-schema.ts
+++ b/tests/schemas/facilities-by-id-schema.ts
@@ -57,6 +57,8 @@ export const facilitiesById = {
               is_verified: { type: "boolean" },
               contributor_name: { type: "string" },
               list_name: { type: ["string", "null"] },
+              contributor_type: { type: "string" },
+              count: { type: "integer" },
             },
             required: ["name"],
             additionalProperties: false,

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -372,7 +372,7 @@ uploadScenarios.forEach(
         }
       });
 
-      test(`[@smokev1] The ${format} list validation before upload.`, async ({ page }) => {
+      test(`[@smokev1][@smokev2] The ${format} list validation before upload.`, async ({ page }) => {
         const { BASE_URL } = process.env;
         await page.goto(`${BASE_URL}/contribute/multiple-locations`);
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -11,7 +11,7 @@ import ExcelJS, { Row, CellValue } from "exceljs";
 
 test.beforeAll(setup);
 
-test("[@smoke] OSDEV-1219: Smoke: Main page. Log-in with valid credentials", async ({
+test("[@smokev1][@smokev2] OSDEV-1219: Smoke: Main page. Log-in with valid credentials", async ({
   page,
   }) => {
     const { BASE_URL, USER_EMAIL, USER_PASSWORD } = process.env;
@@ -33,7 +33,7 @@ test("[@smoke] OSDEV-1219: Smoke: Main page. Log-in with valid credentials", asy
   await loginPage.logoutFromMainPage();
 });
 
-test("[@smoke] OSDEV-1235: Smoke: Django Admin Panel. Log-in with valid credentials", async ({
+test("[@smokev1][@smokev2] OSDEV-1235: Smoke: Django Admin Panel. Log-in with valid credentials", async ({
   page,
   }) => {
     const { BASE_URL, USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD } = process.env;
@@ -46,7 +46,7 @@ test("[@smoke] OSDEV-1235: Smoke: Django Admin Panel. Log-in with valid credenti
 });
 
 test.describe("OSDEV-1233: Smoke: API. Search for valid facilities through an endpoint", () => {
-  test("[@smoke] Get list of facilities from `/facilities` endpoint", async ({
+  test("[@smokev1][@smokev2] Get list of facilities from `/facilities` endpoint", async ({
     request,
   }) => {
     const response = await get(request, "/api/facilities/", {
@@ -77,7 +77,7 @@ test.describe("OSDEV-1233: Smoke: API. Search for valid facilities through an en
     expect(firstFeature.properties).toHaveProperty("country_name");
   });
 
-  test("[@smoke] Get unauthorized response from `/facilities` endpoint", async ({
+  test("[@smokev1][@smokev2] Get unauthorized response from `/facilities` endpoint", async ({
     request,
   }) => {
     const response = await get(request, "/api/facilities/", {
@@ -122,7 +122,7 @@ uploadScenarios.forEach(
     numberOfErrors,
   }) => {
     test.describe(`${testCaseID}: Smoke: Facilities. Upload a list in ${format} format.`, () => {
-      test(`[@smoke] Successful list uploading in ${format} format.`, async ({
+      test(`[@smokev1][@smokev2] Successful list uploading in ${format} format.`, async ({
         page,
       }) => {
         test.setTimeout(25 * 60 * 1000); // Set custom timeout for all test
@@ -372,7 +372,7 @@ uploadScenarios.forEach(
         }
       });
 
-      test(`[@smoke] The ${format} list validation before upload.`, async ({ page }) => {
+      test(`[@smokev1] The ${format} list validation before upload.`, async ({ page }) => {
         const { BASE_URL } = process.env;
         await page.goto(`${BASE_URL}/contribute/multiple-locations`);
 
@@ -450,7 +450,7 @@ uploadScenarios.forEach(
   }
 );
 
-test("[@smoke] OSDEV-1234: Smoke: Create Embedded Map with no facilities on it.", async () => {
+test("[@smokev1][@smokev2] OSDEV-1234: Smoke: Create Embedded Map with no facilities on it.", async () => {
   const browser = await chromium.launch({ headless: true }); // set headless: false to run with UI
   const context = await browser.newContext();
 
@@ -613,7 +613,7 @@ test("[@smoke] OSDEV-1234: Smoke: Create Embedded Map with no facilities on it."
   await adminPage.expectEmbedConfigCreated();
 });
 
-test("[@smoke] OSDEV-1813: Smoke: SLC page is opened, user is able to search by Name and Address, or by OS ID", async ({
+test("[@smokev1][@smokev2] OSDEV-1813: Smoke: SLC page is opened, user is able to search by Name and Address, or by OS ID", async ({
   page,
 }) => {
   const { BASE_URL } = process.env;
@@ -890,7 +890,7 @@ test("[@smoke] OSDEV-1813: Smoke: SLC page is opened, user is able to search by 
 });
 
 test.describe("OSDEV-1232: Home page search combinations", () => {
-  test("[@smoke] OSDEV-1232: Facilities. Invalid search", async ({ page }) => {
+  test("[@smokev1] OSDEV-1232: Facilities. Invalid search", async ({ page }) => {
     const { BASE_URL } = process.env;
     const mainPage = new MainPage(page, BASE_URL!);
 
@@ -916,7 +916,7 @@ test.describe("OSDEV-1232: Home page search combinations", () => {
     await expect(page.getByText("No facilities matching this")).toBeVisible();
   });
 
-  test("[@smoke] OSDEV-1232: Facilities. Valid search", async ({ page }) => {
+  test("[@smokev1] OSDEV-1232: Facilities. Valid search", async ({ page }) => {
     const { BASE_URL } = process.env;
     const mainPage = new MainPage(page, BASE_URL!);
 
@@ -954,7 +954,7 @@ test.describe("OSDEV-1232: Home page search combinations", () => {
     await expect(page.getByText(validSearchQuery).first()).toBeVisible();
   });
 
-  test("[@smoke] OSDEV-1232: Facilities. OSID search", async ({ page }) => {
+  test("[@smokev1] OSDEV-1232: Facilities. OSID search", async ({ page }) => {
     const { BASE_URL } = process.env;
     const mainPage = new MainPage(page, BASE_URL!);
 
@@ -1016,7 +1016,7 @@ test.describe("OSDEV-1232: Home page search combinations", () => {
   ];
 
   countryTestCases.forEach((countryName) => {
-    test(`[@smoke] OSDEV-1232: Facilities. Country Search - ${countryName}`, async ({
+    test(`[@smokev1] OSDEV-1232: Facilities. Country Search - ${countryName}`, async ({
       page,
     }) => {
       const { BASE_URL } = process.env;
@@ -1070,7 +1070,7 @@ test.describe("OSDEV-1232: Home page search combinations", () => {
   ];
 
   facilityTypeTestCases.forEach((facilityType) => {
-    test(`[@smoke] OSDEV-1232: Facilities. Facility Type Search - ${facilityType}`, async ({
+    test(`[@smokev1] OSDEV-1232: Facilities. Facility Type Search - ${facilityType}`, async ({
       page,
     }) => {
       const { BASE_URL } = process.env;
@@ -1167,7 +1167,7 @@ test.describe("OSDEV-1232: Home page search combinations", () => {
   ];
 
   workerRangeTestCases.forEach((testCase) => {
-    test(`[@smoke] OSDEV-1232: Facilities. Filter by Number of Workers - ${testCase.range}`, async ({
+    test(`[@smokev1] OSDEV-1232: Facilities. Filter by Number of Workers - ${testCase.range}`, async ({
       page,
     }) => {
       const { BASE_URL } = process.env;
@@ -1298,7 +1298,7 @@ test.describe("OSDEV-1232: Home page search combinations", () => {
   ];
 
   combinedFilterTestCases.forEach(({ country, facilityType, workerRange }) => {
-    test(`[@smoke] OSDEV-1232: Combined filter - ${country}, ${facilityType}, ${workerRange.range}`, async ({
+    test(`[@smokev1] OSDEV-1232: Combined filter - ${country}, ${facilityType}, ${workerRange.range}`, async ({
       page,
     }) => {
       const { BASE_URL } = process.env;
@@ -1538,7 +1538,12 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
     await expect(page.getByText("# Contributors")).toBeVisible();
 
     // Click the first facility link in the search results
-    const facilityLink = page.locator('a[href*="/facilities/"]').first();
+    //const facilityLink = page.locator('a[href*="/facilities/"]').first();
+    const facilityLink = page
+    .locator(
+      'a[href*="/facilities/"], a[href*="/production-locations/"]'
+    )
+    .first();
     await facilityLink.scrollIntoViewIfNeeded();
     await facilityLink.waitFor({ state: "visible" });
     await facilityLink.click();
@@ -1548,10 +1553,10 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
 
     await expect(page.getByTestId("jump-to-section")).toBeVisible();
     await expect(
-      page.getByTestId("general-information-section")
+      page.getByTestId("production-location-details-general-fields")
     ).toBeVisible();
     await expect(
-      page.getByTestId("operational-details-section")
+      page.getByTestId("spotlight-section")
     ).toBeVisible();
   });
 
@@ -1581,7 +1586,11 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
     await expect(page.getByText("# Contributors")).toBeVisible();
 
     // Click the first facility link in the search results
-    const facilityLink = page.locator('a[href*="/facilities/"]').first();
+    const facilityLink = page
+      .locator(
+        'a[href*="/facilities/"], a[href*="/production-locations/"]'
+      )
+      .first();
     await facilityLink.scrollIntoViewIfNeeded();
     await facilityLink.waitFor({ state: "visible" });
     await facilityLink.click();
@@ -1589,12 +1598,9 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
     // Wait for the page to load
     await page.waitForLoadState("networkidle");
 
-    await expect(page.getByTestId("facility-name-heading")).toBeVisible();
+    await expect(page.getByTestId("location-name")).toBeVisible();
 
-    // Grab the OSID from the page
-    const paragraph = page.locator("p", { hasText: "OS ID: " });
-    await expect(paragraph).toBeVisible();
-    const osID = (await paragraph.locator("span").textContent()) as string;
+    const osID = await mainPage.getOSIDFromLocationPage();
 
     // Navigate back to the search results
     await page.getByRole("button", { name: "Back to search results" }).click();
@@ -1655,7 +1661,11 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
         ).toBeVisible();
 
         // Click first facility link
-        const facilityLink = page.locator('a[href*="/facilities/"]').first();
+        const facilityLink = page
+          .locator(
+            'a[href*="/facilities/"], a[href*="/production-locations/"]'
+          )
+          .first();
         await facilityLink.scrollIntoViewIfNeeded();
         await facilityLink.waitFor({ state: "visible" });
         await facilityLink.click();
@@ -1666,7 +1676,7 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
         const mainPanel = page.locator("#mainPanel");
         await mainPanel.scrollIntoViewIfNeeded();
         await expect(
-          page.getByTestId("general-information-section")
+          page.getByTestId("production-location-details-general-fields")
         ).toBeVisible();
       }
     );
@@ -1719,7 +1729,11 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
         ).toBeVisible();
 
         // Click the first facility link
-        const facilityLink = page.locator('a[href*="/facilities/"]').nth(1);
+        const facilityLink = page
+          .locator(
+            'a[href*="/facilities/"], a[href*="/production-locations/"]'
+          )
+          .nth(1);
         await facilityLink.scrollIntoViewIfNeeded();
         await facilityLink.waitFor({ state: "visible" });
         await facilityLink.click();
@@ -1731,7 +1745,7 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
         await mainPanel.scrollIntoViewIfNeeded();
 
         await expect(
-          page.getByTestId("operational-details-section")
+          page.getByTestId("spotlight-section")
         ).toBeVisible();
       }
     );
@@ -1797,7 +1811,11 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
         await page.waitForLoadState("networkidle");
 
         // Confirm that at least one result is shown
-        const facilityLink = page.locator('a[href*="/facilities/"]').first();
+        const facilityLink = page
+          .locator(
+            'a[href*="/facilities/"], a[href*="/production-locations/"]'
+          )
+          .first();
         await facilityLink.scrollIntoViewIfNeeded();
         await facilityLink.waitFor({ state: "visible" });
         await facilityLink.click();
@@ -1808,7 +1826,7 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
         await mainPanel.scrollIntoViewIfNeeded();
 
         await expect(
-          page.getByTestId("general-information-workers-value")
+          page.getByTestId("gi-workers").getByTestId("data-point-value")
         ).toBeVisible();
       }
     );
@@ -1907,7 +1925,11 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
           await page.waitForLoadState("networkidle");
 
           // Click the first facility link
-          const facilityLink = page.locator('a[href*="/facilities/"]').first();
+          const facilityLink = page
+            .locator(
+              'a[href*="/facilities/"], a[href*="/production-locations/"]'
+            )
+            .first();
           await facilityLink.scrollIntoViewIfNeeded();
           await facilityLink.waitFor({ state: "visible" });
           await facilityLink.click();
@@ -1918,10 +1940,10 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
           await mainPanel.scrollIntoViewIfNeeded();
 
           await expect(
-            page.getByTestId("general-information-section")
+            page.getByTestId("production-location-details-general-fields")
           ).toBeVisible();
           await expect(
-            page.getByTestId("operational-details-section")
+            page.getByTestId("spotlight-section")
           ).toBeVisible();
         }
       );
@@ -1930,7 +1952,7 @@ test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
 });
 
 test.describe("OSDEV-1812: Smoke: Moderation queue page is can be opened through the Dashboard by a Moderation manager.", () => {
-  test("[@smoke] A moderator is able to work with the Moderation Queue page.", async ({
+  test("[@smokev1][@smokev2] A moderator is able to work with the Moderation Queue page.", async ({
     page,
   }) => {
     const { BASE_URL } = process.env;
@@ -2121,7 +2143,7 @@ test.describe("OSDEV-1812: Smoke: Moderation queue page is can be opened through
     ).toBeVisible();
   });
 
-  test("[@smoke] A regular user does not have an access to the Moderation Queue page.", async ({
+  test("[@smokev1][@smokev2] A regular user does not have an access to the Moderation Queue page.", async ({
     page,
   }) => {
     const { BASE_URL } = process.env;
@@ -2163,7 +2185,7 @@ test.describe("OSDEV-1812: Smoke: Moderation queue page is can be opened through
 });
 
 test.describe("OSDEV-1264: Smoke: Download a list of facilities with amounts up to 5000 in xlsx.", async () => {
-  test("[@smoke] An unauthorized user cannot download a list of facilities.", async ({
+  test("[@smokev1][@smokev2] An unauthorized user cannot download a list of facilities.", async ({
     page,
   }) => {
     const { BASE_URL } = process.env;
@@ -2182,7 +2204,7 @@ test.describe("OSDEV-1264: Smoke: Download a list of facilities with amounts up 
     await mainPage.expectDownloadLoginPrompt();
   });
 
-  test("[@smoke] An authorized user can download a list of facilities with amounts 5000 in xlsx.", async ({
+  test("[@smokev1][@smokev2] An authorized user can download a list of facilities with amounts 5000 in xlsx.", async ({
     page,
   }) => {
     const browser = await chromium.launch({ headless: true }); // set headless: false to run with UI
@@ -2298,7 +2320,7 @@ test.describe("OSDEV-1275: Smoke: EM user can see embedded map working properly 
   ];
 
   for (const { name, url } of linksToSitesWhereCheckEM) {
-    test(`[@smoke] Check embedded maps on ${name} website.`, async ({ page }) => {
+    test(`[@smokev1][@smokev2] Check embedded maps on ${name} website.`, async ({ page }) => {
       await page.goto(url, { waitUntil: "networkidle" });
       await page.waitForLoadState("load"); // fires when all resources are loaded
       await page.waitForLoadState("domcontentloaded"); // when HTML is parsed

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -945,6 +945,7 @@ test.describe("OSDEV-1232: Home page search combinations", () => {
     const facilityLink = page.locator('a[href*="/facilities/"]').first();
     await facilityLink.scrollIntoViewIfNeeded();
     await facilityLink.waitFor({ state: "visible" });
+    await facilityLink.click();
 
     // wait for the page to load
     await page.waitForLoadState("networkidle");
@@ -1480,6 +1481,452 @@ test.describe("OSDEV-1232: Home page search combinations", () => {
       ).toBeVisible();
     });
   });
+});
+
+test.describe("OSDEV-1232: Home page search combinations [v2]", () => {
+  test("[@smokev2] OSDEV-1232 v2: Facilities. Invalid search", async ({
+    page,
+  }) => {
+    const { BASE_URL } = process.env;
+    const mainPage = new MainPage(page, BASE_URL!);
+
+    // Navigate to the base URL
+    await mainPage.goTo();
+
+    // Define an invalid search query
+    const invalidSearchQuery = "invalid ABRACADABRA";
+
+    // Click on the search input field and fill it with the invalid query
+    await page.getByPlaceholder("e.g. ABC Textiles Limited").click();
+    await page
+      .getByPlaceholder("e.g. ABC Textiles Limited")
+      .fill(invalidSearchQuery);
+
+    // Click the "Find Facilities" button to perform the search
+    await page.getByRole("button", { name: "Find Facilities" }).click();
+
+    // Wait for the facilities API call to return a 200 status
+    await page.waitForLoadState("networkidle");
+
+    // Assert that the "No facilities matching this" message is visible
+    await expect(page.getByText("No facilities matching this")).toBeVisible();
+  });
+
+  test("[@smokev2] OSDEV-1232 v2: Facilities. Valid search", async ({ page }) => {
+    const { BASE_URL } = process.env;
+    const mainPage = new MainPage(page, BASE_URL!);
+
+    // Navigate to the base URL
+    await mainPage.goTo();
+
+    // Define a valid search query
+    const validSearchQuery = "Fab Lab Re";
+
+    // Click on the search input field and fill it with the valid query
+    await page.getByPlaceholder("e.g. ABC Textiles Limited").click();
+    await page
+      .getByPlaceholder("e.g. ABC Textiles Limited")
+      .fill(validSearchQuery);
+
+    // Click the "Find Facilities" button to perform the search
+    await page.getByRole("button", { name: "Find Facilities" }).click();
+
+    // Wait for the facilities API call to return a 200 status
+    await page.waitForLoadState("networkidle");
+
+    // Assert that the search results are displayed
+    await expect(page.getByText("# Contributors")).toBeVisible();
+
+    // Click the first facility link in the search results
+    const facilityLink = page.locator('a[href*="/facilities/"]').first();
+    await facilityLink.scrollIntoViewIfNeeded();
+    await facilityLink.waitFor({ state: "visible" });
+    await facilityLink.click();
+
+    // wait for the page to load
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("jump-to-section")).toBeVisible();
+    await expect(
+      page.getByTestId("general-information-section")
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("operational-details-section")
+    ).toBeVisible();
+  });
+
+  test("[@smokev2] OSDEV-1232 v2: Facilities. OSID search", async ({ page }) => {
+    const { BASE_URL } = process.env;
+    const mainPage = new MainPage(page, BASE_URL!);
+
+    // Navigate to the base URL
+    await mainPage.goTo();
+
+    // Define a valid search query
+    const validSearchQuery = "Fab Lab Re"; //
+
+    // Click on the search input field and fill it with the valid query
+    await page.getByPlaceholder("e.g. ABC Textiles Limited").click();
+    await page
+      .getByPlaceholder("e.g. ABC Textiles Limited")
+      .fill(validSearchQuery);
+
+    // Click the "Find Facilities" button to perform the search
+    await page.getByRole("button", { name: "Find Facilities" }).click();
+
+    // Wait for the page to load
+    await page.waitForLoadState("networkidle");
+
+    // Assert that the search results are displayed
+    await expect(page.getByText("# Contributors")).toBeVisible();
+
+    // Click the first facility link in the search results
+    const facilityLink = page.locator('a[href*="/facilities/"]').first();
+    await facilityLink.scrollIntoViewIfNeeded();
+    await facilityLink.waitFor({ state: "visible" });
+    await facilityLink.click();
+
+    // Wait for the page to load
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("facility-name-heading")).toBeVisible();
+
+    // Grab the OSID from the page
+    const paragraph = page.locator("p", { hasText: "OS ID: " });
+    await expect(paragraph).toBeVisible();
+    const osID = (await paragraph.locator("span").textContent()) as string;
+
+    // Navigate back to the search results
+    await page.getByRole("button", { name: "Back to search results" }).click();
+
+    // Perform a search using the copied OSID
+    await page.getByPlaceholder("e.g. ABC Textiles Limited").fill(osID);
+    await page.getByRole("button", { name: "Search" }).first().click();
+
+    // Wait for the page to load
+    await page.waitForLoadState("networkidle");
+
+    // Assert that the search results contain the OSID
+    await expect(page.getByText(osID)).toBeVisible();
+  });
+
+  // Test for country search
+  const countryTestCasesV2 = [
+    "United States",
+    "Australia",
+    "United Kingdom",
+    "South Africa",
+  ];
+
+  countryTestCasesV2.forEach((countryName) => {
+    test(
+      `[@smokev2] OSDEV-1232 v2: Facilities. Country Search - ${countryName}`,
+      async ({ page }) => {
+        const { BASE_URL } = process.env;
+        await page.goto(BASE_URL!);
+
+        // Open the country dropdown
+        const countryDropdown = page
+          .locator("#COUNTRIES div")
+          .filter({ hasText: "Select" })
+          .nth(1);
+        await countryDropdown.click();
+
+        // Type and select country
+        const countryInput = countryDropdown.locator("input");
+        await countryInput.fill(countryName);
+        const option = page
+          .locator("#COUNTRIES div")
+          .filter({ hasText: countryName })
+          .nth(1);
+        await option.click();
+        await page.keyboard.press("Enter");
+
+        // Click search
+        const searchButton = page.locator('button[type="submit"]', {
+          hasText: "Find Facilities",
+        });
+        await searchButton.waitFor({ state: "visible" });
+        await searchButton.click();
+
+        // Assert search result contains country name
+        await expect(
+          page.getByText(countryName, { exact: true })
+        ).toBeVisible();
+
+        // Click first facility link
+        const facilityLink = page.locator('a[href*="/facilities/"]').first();
+        await facilityLink.scrollIntoViewIfNeeded();
+        await facilityLink.waitFor({ state: "visible" });
+        await facilityLink.click();
+
+        await page.waitForLoadState("networkidle");
+
+        // Assert facility page contains country name
+        const mainPanel = page.locator("#mainPanel");
+        await mainPanel.scrollIntoViewIfNeeded();
+        await expect(
+          page.getByTestId("general-information-section")
+        ).toBeVisible();
+      }
+    );
+  });
+
+  // Test for facility type search
+  const facilityTypeTestCasesV2 = [
+    "Final Product Assembly",
+    "Raw Material Processing or Production",
+  ];
+
+  facilityTypeTestCasesV2.forEach((facilityType) => {
+    test(
+      `[@smokev2] OSDEV-1232 v2: Facilities. Facility Type Search - ${facilityType}`,
+      async ({ page }) => {
+        const { BASE_URL } = process.env;
+        await page.goto(BASE_URL!);
+        await page.getByRole("button", { name: "Find Facilities" }).click();
+        await page.waitForLoadState("networkidle");
+
+        // Open the FACILITY TYPE dropdown
+        const typeDropdown = page
+          .locator("#FACILITY_TYPE div")
+          .filter({ hasText: "Select" })
+          .first();
+        await typeDropdown.click();
+
+        // Fill and select the facility type
+        const typeInput = typeDropdown.locator("input");
+        await typeInput.fill(facilityType);
+
+        const typeOption = page
+          .locator("#FACILITY_TYPE div")
+          .filter({ hasText: facilityType })
+          .first();
+        await typeOption.click();
+        await page.keyboard.press("Enter");
+
+        // Click the search button *after* selecting the filter
+        const searchButton = page.locator('button[type="submit"]', {
+          hasText: "Search",
+        });
+        await searchButton.waitFor({ state: "visible" });
+        await searchButton.click();
+        await page.waitForLoadState("networkidle");
+
+        // Assert the result page shows the selected facility type
+        await expect(
+          page.getByText(new RegExp(facilityType, "i")).first()
+        ).toBeVisible();
+
+        // Click the first facility link
+        const facilityLink = page.locator('a[href*="/facilities/"]').nth(1);
+        await facilityLink.scrollIntoViewIfNeeded();
+        await facilityLink.waitFor({ state: "visible" });
+        await facilityLink.click();
+
+        await page.waitForLoadState("networkidle");
+
+        // Scroll and wait for the panel
+        const mainPanel = page.locator("#mainPanel");
+        await mainPanel.scrollIntoViewIfNeeded();
+
+        await expect(
+          page.getByTestId("operational-details-section")
+        ).toBeVisible();
+      }
+    );
+  });
+
+  // Test for worker range / number of workers search
+  const workerRangeTestCasesV2 = [
+    {
+      range: "Less than 1000",
+      min: 0,
+      max: 1000,
+    },
+    {
+      range: "1001-5000",
+      min: 1001,
+      max: 5000,
+    },
+    {
+      range: "5001-10000",
+      min: 5001,
+      max: 10000,
+    },
+    {
+      range: "More than 10000",
+      min: 10001,
+      max: Infinity,
+    },
+  ];
+
+  workerRangeTestCasesV2.forEach((testCase) => {
+    test(
+      `[@smokev2] OSDEV-1232 v2: Facilities. Filter by Number of Workers - ${testCase.range}`,
+      async ({ page }) => {
+        const { BASE_URL } = process.env;
+        await page.goto(BASE_URL!);
+        await page.getByRole("button", { name: "Find Facilities" }).click();
+        await page.waitForLoadState("networkidle");
+
+        // Open the NUMBER OF WORKERS dropdown
+        const workersDropdown = page
+          .locator("#NUMBER_OF_WORKERS div")
+          .filter({ hasText: "Select" })
+          .first();
+        await workersDropdown.click();
+
+        // Fill and select the worker range
+        const workersInput = workersDropdown.locator("input");
+        await workersInput.fill(testCase.range);
+
+        const option = page
+          .locator("#NUMBER_OF_WORKERS div")
+          .filter({ hasText: testCase.range })
+          .first();
+        await option.click();
+        await page.keyboard.press("Enter");
+
+        // Click the search button
+        const searchButton = page.locator('button[type="submit"]', {
+          hasText: /search/i,
+        });
+        await searchButton.waitFor({ state: "visible" });
+        await searchButton.click();
+        await page.waitForLoadState("networkidle");
+
+        // Confirm that at least one result is shown
+        const facilityLink = page.locator('a[href*="/facilities/"]').first();
+        await facilityLink.scrollIntoViewIfNeeded();
+        await facilityLink.waitFor({ state: "visible" });
+        await facilityLink.click();
+        await page.waitForLoadState("networkidle");
+
+        // Wait for main content to load
+        const mainPanel = page.locator("#mainPanel");
+        await mainPanel.scrollIntoViewIfNeeded();
+
+        await expect(
+          page.getByTestId("general-information-workers-value")
+        ).toBeVisible();
+      }
+    );
+  });
+
+  // Combined filter test cases
+  const combinedFilterTestCasesV2 = [
+    {
+      country: "United States",
+      facilityType: "Final Product Assembly",
+      workerRange: {
+        range: "Less than 1000",
+        min: 0,
+        max: 1000,
+      },
+    },
+    {
+      country: "United States",
+      facilityType: "Textile or Material Production",
+      workerRange: {
+        range: "Less than 1000",
+        min: 0,
+        max: 1000,
+      },
+    },
+  ];
+
+  combinedFilterTestCasesV2.forEach(
+    ({ country, facilityType, workerRange }) => {
+      test(
+        `[@smokev2] OSDEV-1232 v2: Combined filter - ${country}, ${facilityType}, ${workerRange.range}`,
+        async ({ page }) => {
+          const { BASE_URL } = process.env;
+
+          await page.goto(BASE_URL!);
+          await page.getByRole("button", { name: "Find Facilities" }).click();
+          await page.waitForLoadState("networkidle");
+
+          // COUNTRY filter
+          const countryDropdown = page
+            .locator("#COUNTRIES div")
+            .filter({ hasText: "Select" })
+            .nth(1);
+          await countryDropdown.click();
+
+          const countryInput = countryDropdown.locator("input");
+          await countryInput.fill(country);
+
+          const countryOption = page
+            .locator("#COUNTRIES div")
+            .filter({ hasText: country })
+            .nth(1);
+          await countryOption.click();
+          await page.keyboard.press("Enter");
+
+          // FACILITY TYPE filter
+          const typeDropdown = page
+            .locator("#FACILITY_TYPE div")
+            .filter({ hasText: "Select" })
+            .first();
+          await typeDropdown.click();
+
+          const typeInput = typeDropdown.locator("input");
+          await typeInput.fill(facilityType);
+
+          const typeOption = page
+            .locator("#FACILITY_TYPE div")
+            .filter({ hasText: facilityType })
+            .first();
+          await typeOption.click();
+          await page.keyboard.press("Enter");
+
+          // NUMBER OF WORKERS filter
+          const workersDropdown = page
+            .locator("#NUMBER_OF_WORKERS div")
+            .filter({ hasText: "Select" })
+            .first();
+          await workersDropdown.click();
+
+          const workersInput = workersDropdown.locator("input");
+          await workersInput.fill(workerRange.range);
+
+          const workersOption = page
+            .locator("#NUMBER_OF_WORKERS div")
+            .filter({ hasText: workerRange.range })
+            .first();
+          await workersOption.click();
+          await page.keyboard.press("Enter");
+
+          // Click search
+          const searchButton = page.locator('button[type="submit"]', {
+            hasText: /search/i,
+          });
+          await searchButton.waitFor({ state: "visible" });
+          await searchButton.click();
+          await page.waitForLoadState("networkidle");
+
+          // Click the first facility link
+          const facilityLink = page.locator('a[href*="/facilities/"]').first();
+          await facilityLink.scrollIntoViewIfNeeded();
+          await facilityLink.waitFor({ state: "visible" });
+          await facilityLink.click();
+          await page.waitForLoadState("networkidle");
+
+          // Scroll and wait for the panel
+          const mainPanel = page.locator("#mainPanel");
+          await mainPanel.scrollIntoViewIfNeeded();
+
+          await expect(
+            page.getByTestId("general-information-section")
+          ).toBeVisible();
+          await expect(
+            page.getByTestId("operational-details-section")
+          ).toBeVisible();
+        }
+      );
+    }
+  );
 });
 
 test.describe("OSDEV-1812: Smoke: Moderation queue page is can be opened through the Dashboard by a Moderation manager.", () => {


### PR DESCRIPTION
## Summary
- Retag smoke/API tests from `@smoke` to **`@smokev1`** and **`@smokev2`** so old vs new UI can be run separately or together.
- Add **home search v2** (`@smokev2`) and **facility/production-location v2** smoke coverage
- **`MainPage`**: links include `/production-locations/`; **`getOSIDFromLocationPage()`** via `data-testid="os-id"`.
- New **`admin-wage-indicator-country-data.spec.ts`** for Django admin wage link columns.
- **`facilities-by-id-schema`**: add `contributor_type` and `count` on contributors.
- **`moderation-queue`**: `@Regression` → **`@regression`**.
- **`LoginPage`**: remove duplicate My Account click in the settings flow.
