### PR TITLE
docs: Modernize Docker Compose usage (CLI + compose file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ This project includes Docker configuration for easy setup and consistent testing
 3. **Build and run tests:**
    ```bash
    # Build the Docker image
-   docker-compose build
+   docker compose build
 
    # Run container for tests
-   docker-compose up
+   docker compose up
 
    # Run all tests
-   docker-compose exec e2e-tests npm run test
+   docker compose exec e2e-tests npm run test
 
    # Run smoke tests
-   docker-compose exec e2e-tests npx playwright test --grep "@smoke"
+   docker compose exec e2e-tests npx playwright test --grep "@smoke"
    ```
 
 4. **Access test reports:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   e2e-tests:
     build: .


### PR DESCRIPTION
## Summary

Aligns the project with current Docker Compose practices: Compose V2 CLI syntax in the README and a compose file that no longer declares the obsolete top-level `version` key.

## Changes

### README

- Use `docker compose` instead of the legacy `docker-compose` binary for build, up, and exec commands.

### `docker-compose.yml`

- Remove the deprecated `version: '3.8'` field. Modern Compose uses the [Compose Specification](https://docs.docker.com/compose/compose-file/) without a required `version` attribute; Docker Compose V2 infers the correct behavior from the file.

## Rationale

Compose V2 is integrated with the Docker CLI on current Docker Desktop and Engine setups. Dropping `version` avoids deprecation warnings and matches current compose file guidance.