### PR TITLE
OSDEV-2730 [Test Automation] Create Playwright tests for Data Download Limits

### DIFF
--- a/tests/data/testEM-upto10000.html
+++ b/tests/data/testEM-upto10000.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Your Page Title</title>
+    
+</head>
+
+
+<body>
+    <h1>Your Content Here</h1>
+
+    <!-- iframe src is replaced at runtime from BASE_URL (see loadEmbeddedMapFixtureHtml) -->
+    <iframe src="https://preprod.os-hub.net/facilities?contributors=661&embed=1" frameBorder="0" style="width:1000px;height:1000px" title="embedded-map"></iframe>
+</body>
+</html>

--- a/tests/download-limits.spec.ts
+++ b/tests/download-limits.spec.ts
@@ -6,12 +6,19 @@ import { test, expect, Page } from "@playwright/test";
 import { setup } from "./utils/env";
 import { MainPage } from "./pages/MainPage";
 import { LoginPage } from "./pages/LoginPage";
+import { EmbeddedMapPage } from "./pages/EmbeddedMapPage";
 import {
   resetUserFreeDownloadQuota,
   setUserFreeDownloadQuota,
-} from "../tests/utils/downloadLimits";
+} from "./utils/downloadLimits";
+import { setPrivateInstanceMode, resetPrivateInstanceMode } from "./utils/waffleSwitches";
 
 test.beforeAll(setup);
+
+/** Always turn private_instance off when this spec file finishes (pass or fail). */
+test.afterAll(async () => {
+  await resetPrivateInstanceMode();
+});
 test.describe.configure({ mode: "serial" });
 
 function createPages(page: Page) {
@@ -31,9 +38,40 @@ async function loginAndOpenFilteredSearch(page: Page) {
   return mainPage;
 }
 
+async function openEmbeddedMap(page: Page) {
+  const { BASE_URL } = process.env;
+  const embeddedMap = new EmbeddedMapPage(page, BASE_URL!);
+  await embeddedMap.openFixture();
+  return embeddedMap;
+}
+
+async function loginAndOpenEmbeddedMap(page: Page) {
+  const { loginPage, userEmail, userPassword } = createPages(page);
+  await loginPage.loginViaAuthPage(userEmail, userPassword);
+  return openEmbeddedMap(page);
+}
+
+async function openFilteredSearchInPrivateInstance(page: Page) {
+  const { mainPage } = createPages(page);
+  await mainPage.goToFilteredFacilitiesSearchWithReload();
+  return mainPage;
+}
+
+async function loginAndOpenFilteredSearchInPrivateInstance(page: Page) {
+  const { mainPage, loginPage, userEmail, userPassword } = createPages(page);
+  await loginPage.loginViaAuthPage(userEmail, userPassword);
+  await mainPage.goToFilteredFacilitiesSearchWithReload();
+  return mainPage;
+}
+
 test.describe("[@Regression] Data download quotas and UI", () => {
+  test.beforeAll(async () => {
+    await resetPrivateInstanceMode();
+  });
+
   test.afterAll(async () => {
     await resetUserFreeDownloadQuota();
+    await resetPrivateInstanceMode();
   });
 
   test.describe("Anonymous & authentication", () => {
@@ -104,7 +142,7 @@ test.describe("[@Regression] Data download quotas and UI", () => {
       await resetUserFreeDownloadQuota();
     });
 
-    test("[@Regression] OSDEV-2096: logged-in user within quota sees Download menu with CSV and Excel", async ({
+    test("[@Regression] OSDEV-2110: logged-in user within quota sees Download menu with CSV and Excel", async ({
       page,
     }) => {
       const mainPage = await loginAndOpenFilteredSearch(page);
@@ -166,7 +204,7 @@ test.describe("[@Regression] Data download quotas and UI", () => {
       await resetUserFreeDownloadQuota();
     });
 
-    test("[@Regression] OSDEV-2096: logged-in user within quota triggers facilities-downloads API on CSV", async ({
+    test("[@Regression] OSDEV-2070: logged-in user within quota triggers facilities-downloads API on CSV", async ({
       page,
     }) => {
       test.setTimeout(120000);
@@ -186,6 +224,80 @@ test.describe("[@Regression] Data download quotas and UI", () => {
       const body = await response.json();
       expect(body).toHaveProperty("count");
       expect(body.count).toBeGreaterThan(0);
+    });
+  });
+});
+
+test.describe("[@Regression] Embedded map download limits (testEM-upto10000)", () => {
+  test.describe("10k per-search cap (no annual quota UI)", () => {
+    test("[@Regression] embedded map: anonymous user sees 10k download cap tooltip on Download hover", async ({
+      page,
+    }) => {
+      const embeddedMap = await openEmbeddedMap(page);
+      await embeddedMap.expectResultsWithinEmbedCap();
+      await embeddedMap.expectAnnualQuotaUiHidden();
+      await embeddedMap.hoverDownloadButton();
+      await embeddedMap.expectEmbedResultsLimitTooltip();
+    });
+
+    test("[@Regression] embedded map: anonymous user can open Download menu with CSV and Excel", async ({
+      page,
+    }) => {
+      const embeddedMap = await openEmbeddedMap(page);
+      await embeddedMap.expectResultsWithinEmbedCap();
+      await embeddedMap.expectAnnualQuotaUiHidden();
+      await embeddedMap.expectDownloadMenuOptions();
+    });
+
+    test("[@Regression] embedded map: logged-in user within 10k cap sees Download menu with CSV and Excel", async ({
+      page,
+    }) => {
+      const embeddedMap = await loginAndOpenEmbeddedMap(page);
+      await embeddedMap.expectResultsWithinEmbedCap();
+      await embeddedMap.expectAnnualQuotaUiHidden();
+      await embeddedMap.expectDownloadButtonVisible();
+      await embeddedMap.expectDownloadMenuOptions();
+    });
+  });
+});
+
+test.describe("[@Regression] Private instance mode (10k cap, no annual quota UI)", () => {
+  test.beforeAll(async () => {
+    await setPrivateInstanceMode(true);
+  });
+
+  test.afterAll(async () => {
+    await resetPrivateInstanceMode();
+  });
+
+  test.describe("Main site facilities search", () => {
+    test("[@Regression] private instance: anonymous user sees 10k download cap tooltip on Download hover", async ({
+      page,
+    }) => {
+      const mainPage = await openFilteredSearchInPrivateInstance(page);
+      await mainPage.expectResultsWithinPerSearchCap();
+      await mainPage.expectAnnualQuotaUiHidden();
+      await mainPage.hoverDownloadButton();
+      await mainPage.expectPerSearchDownloadLimitTooltip();
+    });
+
+    test("[@Regression] private instance: anonymous user can open Download menu with CSV and Excel", async ({
+      page,
+    }) => {
+      const mainPage = await openFilteredSearchInPrivateInstance(page);
+      await mainPage.expectResultsWithinPerSearchCap();
+      await mainPage.expectAnnualQuotaUiHidden();
+      await mainPage.expectDownloadMenuOptions();
+    });
+
+    test("[@Regression] private instance: logged-in user within 10k cap sees Download menu with CSV and Excel", async ({
+      page,
+    }) => {
+      const mainPage = await loginAndOpenFilteredSearchInPrivateInstance(page);
+      await mainPage.expectResultsWithinPerSearchCap();
+      await mainPage.expectAnnualQuotaUiHidden();
+      await mainPage.expectDownloadButtonVisible();
+      await mainPage.expectDownloadMenuOptions();
     });
   });
 });

--- a/tests/download-limits.spec.ts
+++ b/tests/download-limits.spec.ts
@@ -228,9 +228,9 @@ test.describe("[@Regression] Data download quotas and UI", () => {
   });
 });
 
-test.describe("[@Regression] Embedded map download limits (testEM-upto10000)", () => {
+test.describe("[@Regression] OSDEV-2102 Embedded map download limits (testEM-upto10000)", () => {
   test.describe("10k per-search cap (no annual quota UI)", () => {
-    test("[@Regression] embedded map: anonymous user sees 10k download cap tooltip on Download hover", async ({
+    test("[@Regression] OSDEV-2102 embedded map: anonymous user sees 10k download cap tooltip on Download hover", async ({
       page,
     }) => {
       const embeddedMap = await openEmbeddedMap(page);
@@ -240,7 +240,7 @@ test.describe("[@Regression] Embedded map download limits (testEM-upto10000)", (
       await embeddedMap.expectEmbedResultsLimitTooltip();
     });
 
-    test("[@Regression] embedded map: anonymous user can open Download menu with CSV and Excel", async ({
+    test("[@Regression] OSDEV-2102 embedded map: anonymous user can open Download menu with CSV and Excel", async ({
       page,
     }) => {
       const embeddedMap = await openEmbeddedMap(page);
@@ -249,7 +249,7 @@ test.describe("[@Regression] Embedded map download limits (testEM-upto10000)", (
       await embeddedMap.expectDownloadMenuOptions();
     });
 
-    test("[@Regression] embedded map: logged-in user within 10k cap sees Download menu with CSV and Excel", async ({
+    test("[@Regression] OSDEV-2102 embedded map: logged-in user within 10k cap sees Download menu with CSV and Excel", async ({
       page,
     }) => {
       const embeddedMap = await loginAndOpenEmbeddedMap(page);
@@ -261,7 +261,7 @@ test.describe("[@Regression] Embedded map download limits (testEM-upto10000)", (
   });
 });
 
-test.describe("[@Regression] Private instance mode (10k cap, no annual quota UI)", () => {
+test.describe("[@Regression] OSDEV-1264 Private instance mode (10k cap, no annual quota UI)", () => {
   test.beforeAll(async () => {
     await setPrivateInstanceMode(true);
   });
@@ -271,7 +271,7 @@ test.describe("[@Regression] Private instance mode (10k cap, no annual quota UI)
   });
 
   test.describe("Main site facilities search", () => {
-    test("[@Regression] private instance: anonymous user sees 10k download cap tooltip on Download hover", async ({
+    test("[@Regression] OSDEV-1264 private instance: anonymous user sees 10k download cap tooltip on Download hover", async ({
       page,
     }) => {
       const mainPage = await openFilteredSearchInPrivateInstance(page);
@@ -281,7 +281,7 @@ test.describe("[@Regression] Private instance mode (10k cap, no annual quota UI)
       await mainPage.expectPerSearchDownloadLimitTooltip();
     });
 
-    test("[@Regression] private instance: anonymous user can open Download menu with CSV and Excel", async ({
+    test("[@Regression] OSDEV-1264 private instance: anonymous user can open Download menu with CSV and Excel", async ({
       page,
     }) => {
       const mainPage = await openFilteredSearchInPrivateInstance(page);
@@ -290,7 +290,7 @@ test.describe("[@Regression] Private instance mode (10k cap, no annual quota UI)
       await mainPage.expectDownloadMenuOptions();
     });
 
-    test("[@Regression] private instance: logged-in user within 10k cap sees Download menu with CSV and Excel", async ({
+    test("[@Regression] OSDEV-1264 private instance: logged-in user within 10k cap sees Download menu with CSV and Excel", async ({
       page,
     }) => {
       const mainPage = await loginAndOpenFilteredSearchInPrivateInstance(page);

--- a/tests/download-limits.spec.ts
+++ b/tests/download-limits.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * E2E coverage for Data Download Limits (QAlity folder: Data Download and Limits).
+ * Epic: OSDEV-2192 — https://opensupplyhub.atlassian.net/browse/OSDEV-2192
+ */
+import { test, expect, Page } from "@playwright/test";
+import { setup } from "./utils/env";
+import { MainPage } from "./pages/MainPage";
+import { LoginPage } from "./pages/LoginPage";
+import {
+  resetUserFreeDownloadQuota,
+  setUserFreeDownloadQuota,
+} from "../tests/utils/downloadLimits";
+
+test.beforeAll(setup);
+test.describe.configure({ mode: "serial" });
+
+function createPages(page: Page) {
+  const { BASE_URL, USER_EMAIL, USER_PASSWORD } = process.env;
+  return {
+    mainPage: new MainPage(page, BASE_URL!),
+    loginPage: new LoginPage(page, BASE_URL!),
+    userEmail: USER_EMAIL!,
+    userPassword: USER_PASSWORD!,
+  };
+}
+
+async function loginAndOpenFilteredSearch(page: Page) {
+  const { mainPage, loginPage, userEmail, userPassword } = createPages(page);
+  await loginPage.loginViaAuthPage(userEmail, userPassword);
+  await mainPage.goToFilteredFacilitiesSearch();
+  return mainPage;
+}
+
+test.describe("[@Regression] Data download quotas and UI", () => {
+  test.afterAll(async () => {
+    await resetUserFreeDownloadQuota();
+  });
+
+  test.describe("Anonymous & authentication", () => {
+    test("[@Regression] OSDEV-2069: anonymous user sees login tooltip on Download hover", async ({
+      page,
+    }) => {
+      const { mainPage } = createPages(page);
+      await mainPage.goToFilteredFacilitiesSearch();
+      await mainPage.hoverDownloadButton();
+      await mainPage.expectAnonymousDownloadTooltip();
+    });
+
+    test("[@Regression] OSDEV-2069: anonymous user is prompted to log in when selecting Excel download", async ({
+      page,
+    }) => {
+      const { mainPage } = createPages(page);
+      await mainPage.goToFilteredFacilitiesSearch();
+      await mainPage.downloadFacilities("Excel");
+      await mainPage.expectDownloadLoginPrompt();
+    });
+  });
+
+  test.describe("Lead-in copy (DownloadLimitInfo)", () => {
+    test.beforeEach(async () => {
+      await resetUserFreeDownloadQuota();
+    });
+
+    test("[@Regression] OSDEV-2080: lead-in is hidden when results are within annual quota", async ({
+      page,
+    }) => {
+      const mainPage = await loginAndOpenFilteredSearch(page);
+      const resultCount = await mainPage.getResultsCount();
+      expect(resultCount).toBeGreaterThan(0);
+      expect(resultCount).toBeLessThanOrEqual(5000);
+
+      await mainPage.expectDownloadLeadInHidden();
+      await mainPage.expectPurchaseButtonHidden();
+    });
+
+    test("[@Regression] OSDEV-2105: lead-in is visible when filtered results exceed remaining quota", async ({
+      page,
+    }) => {
+      await setUserFreeDownloadQuota("100");
+      const mainPage = await loginAndOpenFilteredSearch(page);
+
+      await mainPage.expectDownloadLeadInVisible();
+      await mainPage.expectLeadInMentionsAnnualFreeLimit();
+    });
+
+    test("[@Regression] OSDEV-2682: lead-in is hidden on unfiltered search", async ({ page }) => {
+      await setUserFreeDownloadQuota("100");
+      const { mainPage, loginPage, userEmail, userPassword } = createPages(page);
+      await loginPage.loginViaAuthPage(userEmail, userPassword);
+      await mainPage.goToUnfilteredFacilitiesSearch();
+
+      await mainPage.expectDownloadLeadInHidden();
+    });
+
+    test("[@Regression] lead-in is hidden for anonymous users", async ({ page }) => {
+      const { mainPage } = createPages(page);
+      await mainPage.goToFilteredFacilitiesSearch();
+      await mainPage.expectDownloadLeadInHidden();
+    });
+  });
+
+  test.describe("Download button states & tooltips", () => {
+    test.beforeEach(async () => {
+      await resetUserFreeDownloadQuota();
+    });
+
+    test("[@Regression] OSDEV-2096: logged-in user within quota sees Download menu with CSV and Excel", async ({
+      page,
+    }) => {
+      const mainPage = await loginAndOpenFilteredSearch(page);
+      await mainPage.expectDownloadButtonVisible();
+      await mainPage.expectPurchaseButtonHidden();
+      await mainPage.expectDownloadMenuOptions();
+    });
+
+    test("[@Regression] OSDEV-2104: over-quota user sees Purchase More Downloads with mismatch tooltip", async ({
+      page,
+    }) => {
+      await setUserFreeDownloadQuota("100");
+      const mainPage = await loginAndOpenFilteredSearch(page);
+
+      await mainPage.expectPurchaseButtonVisible();
+      await mainPage.hoverPurchaseButton();
+      await mainPage.expectOverQuotaPurchaseTooltip(100);
+    });
+
+    test("[@Regression] OSDEV-2104: exhausted quota user sees annual limit reached tooltip", async ({
+      page,
+    }) => {
+      await setUserFreeDownloadQuota("0");
+      const mainPage = await loginAndOpenFilteredSearch(page);
+
+      await mainPage.expectPurchaseButtonVisible();
+      await mainPage.hoverPurchaseButton();
+      await mainPage.expectExhaustedQuotaTooltip();
+    });
+  });
+
+  test.describe("Purchase CTA", () => {
+    test.beforeEach(async () => {
+      await setUserFreeDownloadQuota("100");
+    });
+
+    test("[@Regression] OSDEV-2081: Purchase More Downloads triggers checkout session request", async ({
+      page,
+    }) => {
+      const mainPage = await loginAndOpenFilteredSearch(page);
+
+      const checkoutRequest = page.waitForRequest(
+        (req) =>
+          req.method() === "POST" &&
+          (req.url().includes("checkout") ||
+            req.url().includes("stripe") ||
+            req.url().includes("session")),
+        { timeout: 30000 }
+      );
+
+      await mainPage.clickPurchaseMoreDownloads();
+      const request = await checkoutRequest;
+      expect(request.url()).toBeTruthy();
+    });
+  });
+
+  test.describe("Download actions", () => {
+    test.beforeEach(async () => {
+      await resetUserFreeDownloadQuota();
+    });
+
+    test("[@Regression] OSDEV-2096: logged-in user within quota triggers facilities-downloads API on CSV", async ({
+      page,
+    }) => {
+      test.setTimeout(120000);
+
+      const mainPage = await loginAndOpenFilteredSearch(page);
+
+      const downloadResponse = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/facilities-downloads/") &&
+          resp.request().method() === "GET" &&
+          resp.status() < 400,
+        { timeout: 90000 }
+      );
+
+      await mainPage.downloadFacilities("CSV");
+      const response = await downloadResponse;
+      const body = await response.json();
+      expect(body).toHaveProperty("count");
+      expect(body.count).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/pages/AdminPage.ts
+++ b/tests/pages/AdminPage.ts
@@ -125,6 +125,13 @@ export class AdminPage extends BasePage {
     await this.waitForLoadState();
   }
 
+  async setUserFreeDownloadQuota(userEmail: string, freeRecords: string) {
+    await this.goToDownloadLimits();
+    await this.searchUserDownloadLimit(userEmail);
+    await this.clickFirstRowLinkDownloadLimit();
+    await this.setFreeDownloadRecords(freeRecords);
+  }
+
   async expectSuccessMessageForDownloadLimit() {
     await this.expectToBeVisible(this.successMessageForDownloadLimit());
   }

--- a/tests/pages/AdminPage.ts
+++ b/tests/pages/AdminPage.ts
@@ -135,4 +135,43 @@ export class AdminPage extends BasePage {
   async expectSuccessMessageForDownloadLimit() {
     await this.expectToBeVisible(this.successMessageForDownloadLimit());
   }
+
+  async goToWaffleSwitches() {
+    await this.goTo("/admin/waffle/switch/");
+    await this.expectToBeVisible(this.page.getByText("Select switch to change"));
+  }
+
+  async openWaffleSwitchChangeForm(switchName: string) {
+    await this.goToWaffleSwitches();
+    await this.searchInput().fill(switchName);
+    await this.searchButton().click();
+    await this.waitForLoadState();
+
+    const row = this.page.locator("table#result_list tbody tr").filter({ hasText: switchName });
+    await expect(row).toHaveCount(1);
+    await row.locator("a").first().click();
+    await this.waitForLoadState();
+    await this.expectToBeVisible(this.page.locator("#id_active"));
+  }
+
+  async setWaffleSwitchActive(switchName: string, active: boolean) {
+    await this.openWaffleSwitchChangeForm(switchName);
+
+    const activeCheckbox = this.page.locator("#id_active");
+    const isChecked = await activeCheckbox.isChecked();
+    if (isChecked !== active) {
+      if (active) {
+        await activeCheckbox.check();
+      } else {
+        await activeCheckbox.uncheck();
+      }
+      await this.saveChanges();
+      await this.expectToBeVisible(
+        this.page.getByText("The switch").and(this.page.getByText("was changed successfully."))
+      );
+    }
+
+    await this.openWaffleSwitchChangeForm(switchName);
+    await expect(activeCheckbox).toBeChecked({ checked: active });
+  }
 } 

--- a/tests/pages/BasePage.ts
+++ b/tests/pages/BasePage.ts
@@ -50,4 +50,11 @@ export class BasePage {
   async getCurrentUrl(): Promise<string> {
     return this.page.url();
   }
+
+  async acceptCookiesIfPresent() {
+    const accept = this.page.getByRole("button", { name: /^accept$/i });
+    if (await accept.isVisible().catch(() => false)) {
+      await accept.click();
+    }
+  }
 } 

--- a/tests/pages/EmbeddedMapPage.ts
+++ b/tests/pages/EmbeddedMapPage.ts
@@ -1,0 +1,102 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { FrameLocator, Page, expect } from "@playwright/test";
+import {
+  EMBED_DOWNLOAD_RESULTS_LIMIT,
+  loadEmbeddedMapFixtureHtml,
+} from "../utils/downloadLimits";
+
+/**
+ * Download UI inside the embedded map iframe (tests/data/testEM-upto10000.html).
+ * Embed mode has a per-search download cap (10k results), not annual account quotas.
+ */
+export class EmbeddedMapPage {
+  private mapFrame = (): FrameLocator =>
+    this.page.frameLocator('iframe[title="embedded-map"]');
+
+  constructor(
+    private readonly page: Page,
+    private readonly baseUrl: string
+  ) {}
+
+  async openFixture() {
+    await this.page.setViewportSize({ width: 1200, height: 1200 });
+    const html = loadEmbeddedMapFixtureHtml(this.baseUrl);
+    const fixturePath = path.join(os.tmpdir(), "oshub-testEM-upto10000.html");
+    fs.writeFileSync(fixturePath, html);
+    await this.page.goto(`file://${fixturePath}`);
+    await this.waitForMapReady();
+  }
+
+  async waitForMapReady() {
+    const frame = this.mapFrame();
+    const accept = frame.getByRole("button", { name: /^accept$/i });
+    if (await accept.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await accept.evaluate((el) => (el as HTMLElement).click());
+    }
+    await frame.getByText(/^\d+ results$/).waitFor({ state: "visible", timeout: 60000 });
+  }
+
+  async expectResultsWithinEmbedCap() {
+    const resultCount = await this.getResultsCount();
+    expect(resultCount).toBeGreaterThan(0);
+    expect(resultCount).toBeLessThanOrEqual(EMBED_DOWNLOAD_RESULTS_LIMIT);
+  }
+
+  private downloadButton = () => this.mapFrame().getByRole("button", { name: "Download" });
+  private purchaseButton = () =>
+    this.mapFrame().getByRole("button", { name: "Purchase More Downloads" });
+  private csvMenuItem = () => this.mapFrame().getByRole("menuitem", { name: "CSV" });
+  private excelMenuItem = () => this.mapFrame().getByRole("menuitem", { name: "Excel" });
+  private tooltip = () => this.mapFrame().locator("[role=tooltip]");
+  private annualQuotaLeadIn = () =>
+    this.mapFrame().getByText(
+      /All registered accounts can download up to 5000 production locations annually for free/i
+    );
+  private resultsText = () => this.mapFrame().getByText(/^\d+ results$/);
+
+  async openDownloadMenu() {
+    await this.downloadButton().click({ force: true });
+    await this.csvMenuItem().waitFor({ state: "visible" });
+  }
+
+  async downloadFacilities(format: "CSV" | "Excel") {
+    await this.openDownloadMenu();
+    const menuItem = format === "CSV" ? this.csvMenuItem() : this.excelMenuItem();
+    await menuItem.click({ force: true });
+  }
+
+  async hoverDownloadButton() {
+    await this.downloadButton().hover();
+    await this.tooltip().first().waitFor({ state: "visible" });
+  }
+
+  async expectDownloadButtonVisible() {
+    await expect(this.downloadButton()).toBeVisible();
+  }
+
+  async expectEmbedResultsLimitTooltip() {
+    await expect(this.tooltip()).toContainText(
+      `Downloads are supported for searches resulting in ${EMBED_DOWNLOAD_RESULTS_LIMIT} production locations or less`
+    );
+  }
+
+  async expectDownloadMenuOptions() {
+    await this.openDownloadMenu();
+    await expect(this.csvMenuItem()).toBeVisible();
+    await expect(this.excelMenuItem()).toBeVisible();
+    await this.page.keyboard.press("Escape");
+  }
+
+  /** Annual quota UI (purchase CTA, 5000 lead-in) is not shown in embed mode. */
+  async expectAnnualQuotaUiHidden() {
+    await expect(this.purchaseButton()).toHaveCount(0);
+    await expect(this.annualQuotaLeadIn()).toHaveCount(0);
+  }
+
+  async getResultsCount(): Promise<number> {
+    const text = await this.resultsText().textContent();
+    return parseInt(text?.match(/\d+/)?.[0] || "0", 10);
+  }
+}

--- a/tests/pages/LoginPage.ts
+++ b/tests/pages/LoginPage.ts
@@ -12,7 +12,6 @@ export class LoginPage extends BasePage {
   private logoutButton = () => this.page.getByRole("button", { name: "Log Out" });
   private loginRegisterLink = () => this.page.getByRole("link", { name: "Login/Register" });
   private settingsLink = () => this.page.getByRole("link", { name: "Settings" });
-  private acceptButton = () => this.page.getByRole("button", { name: "Accept" });
 
   constructor(page: Page, baseUrl: string) {
     super(page, baseUrl);
@@ -21,32 +20,25 @@ export class LoginPage extends BasePage {
   // Main page authentication methods
   async loginToMainPage(email: string, password: string) {
     await this.goTo();
-    
-    // Accept cookies if present
-    try {
-      await this.acceptButton().click();
-    } catch (error) {
-      console.log(`An error has happened during accepting cookies: ${error}`);
-    }
-
-    // Navigate to login
+    await this.acceptCookiesIfPresent();
     await this.loginRegisterLink().click();
-    
-    // Fill credentials
-    await this.emailInput().fill(email);
-    await this.passwordInput().fill(password);
-    await this.loginButton().click();
-    
-    // Wait for successful login
+    await this.completeLoginForm(email, password);
+    await this.expectToBeVisible(this.myAccountButton());
+  }
+
+  async loginViaAuthPage(email: string, password: string) {
+    await this.goTo("/auth/login");
+    await this.page.locator("#LOGIN_EMAIL").fill(email);
+    await this.page.locator("#LOGIN_PASSWORD").fill(password);
+    await this.page.getByRole("button", { name: "LOG IN" }).click();
     await this.expectToBeVisible(this.myAccountButton());
   }
 
   async completeLoginForm(email: string, password: string) {
-    // Fill credentials
     await this.emailInput().fill(email);
     await this.passwordInput().fill(password);
     await this.loginButton().click();
-    
+
     await this.waitForLoadState();
     await this.page.waitForTimeout(2000);
   }
@@ -54,12 +46,10 @@ export class LoginPage extends BasePage {
   async logoutFromMainPage() {
     await this.myAccountButton().click();
     await this.expectToBeVisible(this.logoutButton());
-    await this.logoutButton().click();
-    
-    // Wait for logout response
+    await this.logoutButton().click({ force: true });
+
     await this.waitForResponse("/user-logout/", 204);
-    
-    // Verify logout
+
     await expect(this.page.getByText("text=My Account")).not.toBeVisible();
     await this.expectToBeVisible(this.loginRegisterLink());
   }
@@ -68,24 +58,21 @@ export class LoginPage extends BasePage {
     await this.myAccountButton().click();
     await this.settingsLink().click();
     await this.page.isVisible(`text=${email}`);
-
+    await this.myAccountButton().click();
   }
 
   // Admin panel authentication methods
   async loginToAdminPanel(email: string, password: string) {
     await this.goTo("/admin/");
-    
-    // Verify we're on admin login page
+
     const title = await this.page.title();
     expect(title).toBe("Log in | Django site admin");
     await this.expectToBeVisible(this.page.getByText("Open Supply Hub Admin"));
-    
-    // Fill admin credentials
+
     await this.adminEmailInput().fill(email);
     await this.adminPasswordInput().fill(password);
     await this.loginButton().click();
-    
-    // Verify successful admin login
+
     await this.expectToBeVisible(this.page.getByRole("link", { name: "Open Supply Hub Admin" }));
     await this.expectToBeVisible(this.page.getByText("Site administration"));
     await this.expectToBeVisible(this.page.getByRole("button", { name: "Log out" }));
@@ -93,7 +80,7 @@ export class LoginPage extends BasePage {
 
   async logoutFromAdminPanel() {
     await this.page.getByRole("button", { name: "Log out" }).click();
-    
+
     await expect(this.page.getByText("Log in again")).toBeVisible();
   }
 
@@ -129,4 +116,4 @@ export class LoginPage extends BasePage {
       return false;
     }
   }
-} 
+}

--- a/tests/pages/MainPage.ts
+++ b/tests/pages/MainPage.ts
@@ -1,6 +1,9 @@
 import { Page, expect } from "@playwright/test";
 import { BasePage } from "./BasePage";
-import { FILTERED_FACILITIES_PATH } from "../utils/downloadLimits";
+import {
+  EMBED_DOWNLOAD_RESULTS_LIMIT,
+  FILTERED_FACILITIES_PATH,
+} from "../utils/downloadLimits";
 
 export class MainPage extends BasePage {
   // Locators
@@ -112,6 +115,13 @@ export class MainPage extends BasePage {
     await this.goToFacilitiesSearch(FILTERED_FACILITIES_PATH);
   }
 
+  async goToFilteredFacilitiesSearchWithReload() {
+    await this.goToFacilitiesSearch(FILTERED_FACILITIES_PATH);
+    await this.page.reload({ waitUntil: "networkidle" });
+    await this.acceptCookiesIfPresent();
+    await this.resultsText().waitFor({ state: "visible", timeout: 60000 });
+  }
+
   async goToUnfilteredFacilitiesSearch() {
     await this.goToFacilitiesSearch("/facilities/");
   }
@@ -158,6 +168,23 @@ export class MainPage extends BasePage {
 
   async expectAnonymousDownloadTooltip() {
     await expect(this.tooltip()).toContainText("Log in or sign up to download this dataset.");
+  }
+
+  async expectPerSearchDownloadLimitTooltip() {
+    await expect(this.tooltip()).toContainText(
+      `Downloads are supported for searches resulting in ${EMBED_DOWNLOAD_RESULTS_LIMIT} production locations or less`
+    );
+  }
+
+  async expectResultsWithinPerSearchCap() {
+    const resultCount = await this.getResultsCount();
+    expect(resultCount).toBeGreaterThan(0);
+    expect(resultCount).toBeLessThanOrEqual(EMBED_DOWNLOAD_RESULTS_LIMIT);
+  }
+
+  async expectAnnualQuotaUiHidden() {
+    await this.expectPurchaseButtonHidden();
+    await this.expectDownloadLeadInHidden();
   }
 
   async expectDownloadMenuOptions() {

--- a/tests/pages/MainPage.ts
+++ b/tests/pages/MainPage.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from "@playwright/test";
 import { BasePage } from "./BasePage";
+import { FILTERED_FACILITIES_PATH } from "../utils/downloadLimits";
 
 export class MainPage extends BasePage {
   // Locators
@@ -7,11 +8,19 @@ export class MainPage extends BasePage {
   private findFacilitiesButton = () => this.page.getByRole("button", { name: "Find Facilities" });
   private searchButton = () => this.page.getByRole("button", { name: "Search" });
   private downloadButton = () => this.page.getByRole("button", { name: "Download" });
+  private purchaseButton = () =>
+    this.page.getByRole("button", { name: "Purchase More Downloads" });
+  private csvMenuItem = () => this.page.getByRole("menuitem", { name: "CSV" });
   private excelMenuItem = () => this.page.getByRole("menuitem", { name: "Excel" });
   private loginToDownloadHeading = () => this.page.getByRole("heading", { name: "Log In To Download" });
   private cancelButton = () => this.page.getByRole("button", { name: "CANCEL" });
   private registerButton = () => this.page.getByRole("button", { name: "REGISTER" });
   private loginButton = () => this.page.getByRole("button", { name: "LOG IN" });
+  private tooltip = () => this.page.locator("[role=tooltip]");
+  private downloadLeadIn = () =>
+    this.page.getByText(
+      /All registered accounts can download up to 5000 production locations annually for free/i
+    );
   private noFacilitiesMessage = () => this.page.getByText("No facilities matching this");
   private contributorsText = () => this.page.getByText("# Contributors");
   private facilityLinks = () =>
@@ -29,8 +38,8 @@ export class MainPage extends BasePage {
     super(page, baseUrl);
   }
 
-  async goTo() {
-    await super.goTo();
+  async goTo(path: string = "") {
+    await super.goTo(path);
   }
 
   async verifyPageTitle() {
@@ -93,10 +102,47 @@ export class MainPage extends BasePage {
     await this.waitForLoadState();
   }
 
-  async downloadFacilitiesExcel() {
+  async goToFacilitiesSearch(path: string = "/facilities/") {
+    await this.goTo(path);
+    await this.acceptCookiesIfPresent();
+    await this.resultsText().waitFor({ state: "visible", timeout: 60000 });
+  }
+
+  async goToFilteredFacilitiesSearch() {
+    await this.goToFacilitiesSearch(FILTERED_FACILITIES_PATH);
+  }
+
+  async goToUnfilteredFacilitiesSearch() {
+    await this.goToFacilitiesSearch("/facilities/");
+  }
+
+  async openDownloadMenu() {
     await this.downloadButton().click({ force: true });
-    await this.waitForLoadState();
-    await this.excelMenuItem().click({ force: true });
+    await this.csvMenuItem().waitFor({ state: "visible" });
+  }
+
+  async downloadFacilities(format: "CSV" | "Excel") {
+    await this.openDownloadMenu();
+    const menuItem = format === "CSV" ? this.csvMenuItem() : this.excelMenuItem();
+    await menuItem.click({ force: true });
+  }
+
+  async downloadFacilitiesExcel() {
+    await this.downloadFacilities("Excel");
+  }
+
+  async hoverDownloadButton() {
+    await this.downloadButton().hover();
+    await this.tooltip().first().waitFor({ state: "visible" });
+  }
+
+  async hoverPurchaseButton() {
+    await this.purchaseButton().hover();
+    await this.tooltip().first().waitFor({ state: "visible" });
+  }
+
+  async clickPurchaseMoreDownloads() {
+    await this.purchaseButton().click();
   }
 
   async expectDownloadLoginPrompt() {
@@ -104,6 +150,60 @@ export class MainPage extends BasePage {
     await this.expectToBeVisible(this.cancelButton());
     await this.expectToBeVisible(this.registerButton());
     await this.expectToBeVisible(this.loginButton());
+  }
+
+  async expectDownloadButtonVisible() {
+    await this.expectToBeVisible(this.downloadButton());
+  }
+
+  async expectAnonymousDownloadTooltip() {
+    await expect(this.tooltip()).toContainText("Log in or sign up to download this dataset.");
+  }
+
+  async expectDownloadMenuOptions() {
+    await this.openDownloadMenu();
+    await this.expectToBeVisible(this.csvMenuItem());
+    await this.expectToBeVisible(this.excelMenuItem());
+    await this.page.keyboard.press("Escape");
+  }
+
+  async expectPurchaseButtonVisible() {
+    await this.expectToBeVisible(this.purchaseButton());
+  }
+
+  async expectPurchaseButtonHidden() {
+    await expect(this.purchaseButton()).toHaveCount(0);
+  }
+
+  async expectDownloadLeadInVisible() {
+    await this.expectToBeVisible(this.downloadLeadIn());
+  }
+
+  async expectDownloadLeadInHidden() {
+    await expect(this.downloadLeadIn()).toHaveCount(0);
+  }
+
+  async expectLeadInMentionsAnnualFreeLimit() {
+    await expect(this.downloadLeadIn()).toContainText("5000");
+    await expect(this.downloadLeadIn()).toContainText("annually");
+  }
+
+  async expectOverQuotaPurchaseTooltip(availableRecords: number) {
+    const resultCount = await this.getResultsCount();
+    await expect(this.tooltip()).toContainText(
+      `You are trying to download ${resultCount} production locations`
+    );
+    await expect(this.tooltip()).toContainText(
+      `${availableRecords} production locations available to download`
+    );
+    await expect(this.tooltip()).toContainText("Purchase additional downloads");
+  }
+
+  async expectExhaustedQuotaTooltip() {
+    await expect(this.tooltip()).toContainText(
+      "You've reached your annual download limit of 5000 production"
+    );
+    await expect(this.tooltip()).toContainText("Purchase additional downloads");
   }
 
   async expectNoFacilitiesMessage() {
@@ -148,4 +248,4 @@ export class MainPage extends BasePage {
   async goBackToSearchResults() {
     await this.page.getByRole("button", { name: "Back to search results" }).click();
   }
-} 
+}

--- a/tests/pages/README.md
+++ b/tests/pages/README.md
@@ -11,6 +11,7 @@ tests/pages/
 ├── MainPage.ts          # Main page functionality (search, navigation, downloads)
 ├── AdminPage.ts         # Django admin contributor/download-limit operations
 ├── AdminDashboardPage.ts  # Dashboard moderation queue access and assertions
+├── EmbeddedMapPage.ts   # Embedded map iframe (download limits via testEM-upto10000.html)
 └── README.md           # This documentation
 ```
 
@@ -34,10 +35,11 @@ Authentication flows for both the main app and Django admin.
 ### MainPage
 Public main-site search, results, and download-quota UI behavior.
 
-- Navigation/title: `goTo`, `verifyPageTitle`, `goToFilteredFacilitiesSearch`, `goToUnfilteredFacilitiesSearch`
+- Navigation/title: `goTo`, `verifyPageTitle`, `goToFilteredFacilitiesSearch`, `goToFilteredFacilitiesSearchWithReload`, `goToUnfilteredFacilitiesSearch`
 - Search and filters: `searchFacilities`, `searchByOSID`, `searchByCountry`, `searchByFacilityType`, `searchByWorkerRange`, `performSearch`
 - Results actions: `clickFirstFacility`, `goBackToSearchResults`, `downloadFacilities`, `downloadFacilitiesExcel`
 - Download quota UI: lead-in copy, purchase button, tooltips (`expectDownloadLeadIn*`, `expectPurchaseButton*`, `expectOverQuotaPurchaseTooltip`, etc.)
+- Private instance / per-search cap: `expectPerSearchDownloadLimitTooltip`, `expectResultsWithinPerSearchCap`, `expectAnnualQuotaUiHidden`
 - Assertions: `expectSearchResults`, `expectNoFacilitiesMessage`, `expectFacilityInResults`, `expectOSIDInResults`, `expectCountryInResults`, `expectDownloadLoginPrompt`
 - Data helpers: `getResultsCount`, `getOSIDFromLocationPage`, `getOSIDFromFacilityPage`
 
@@ -47,6 +49,16 @@ Django admin flows for contributors and download limits.
 - Contributor flow: `goToContributors`, `searchContributor`, `clickFirstContributor`, `expectChangeContributorPage`, `expectAdminEmail`
 - Embed config flow: `clearEmbedConfiguration`, `setEmbedLevel`, `setEmbedLevelToDeluxe`, `saveChanges`, `expectEmbedConfigCreated`, `getEmbedConfigValue`, `expectSuccessMessageForContributor`
 - Download-limit flow: `goToDownloadLimits`, `setUserFreeDownloadQuota`, `setFreeDownloadRecords`, `expectSuccessMessageForDownloadLimit`
+- Waffle switches: `goToWaffleSwitches`, `setWaffleSwitchActive` (e.g. `private_instance`)
+
+### EmbeddedMapPage
+Download UI inside an embedded map loaded from `tests/data/testEM-upto10000.html`.
+
+- Fixture: `openFixture`, `waitForMapReady`
+- Embed cap (10k results per search): `expectResultsWithinEmbedCap`, `expectEmbedResultsLimitTooltip`
+- Auth/download: `expectEmbedResultsLimitTooltip`, `expectDownloadMenuOptions`
+- Embed has no annual quota UI: `expectAnnualQuotaUiHidden`
+- Data helpers: `getResultsCount`
 
 ### AdminDashboardPage
 Dashboard moderation-queue navigation and access assertions.

--- a/tests/pages/README.md
+++ b/tests/pages/README.md
@@ -21,22 +21,23 @@ Base class extended by all page objects.
 
 - Navigation: (`goTo`, `getCurrentUrl()`)
 - Wait helpers: (`waitForLoadState`, `waitForResponse`)
-- Common interactions: (`clickButton`, `clickLink`, `fillInput`)
+- Common interactions: (`clickButton`, `clickLink`, `fillInput`, `acceptCookiesIfPresent`)
 - Assertion helpers: (`expectToBeVisible`, `expectToHaveText`, `expectToHaveValue`)
 
 ### LoginPage
 Authentication flows for both the main app and Django admin.
 
-- Main app: `loginToMainPage`, `completeLoginForm`, `logoutFromMainPage`, `verifyMainPageLogin`, `isLoggedIn`
+- Main app: `loginToMainPage`, `loginViaAuthPage`, `completeLoginForm`, `logoutFromMainPage`, `verifyMainPageLogin`, `isLoggedIn`
 - Admin app: `loginToAdminPanel`, `logoutFromAdminPanel`, `verifyAdminPanelLogin`, `isAdminLoggedIn`
 - Utility: `getPageTitle`
 
 ### MainPage
-Public main-site search and results behavior.
+Public main-site search, results, and download-quota UI behavior.
 
-- Navigation/title: `goTo`, `verifyPageTitle`
+- Navigation/title: `goTo`, `verifyPageTitle`, `goToFilteredFacilitiesSearch`, `goToUnfilteredFacilitiesSearch`
 - Search and filters: `searchFacilities`, `searchByOSID`, `searchByCountry`, `searchByFacilityType`, `searchByWorkerRange`, `performSearch`
-- Results actions: `clickFirstFacility`, `goBackToSearchResults`, `downloadFacilitiesExcel`
+- Results actions: `clickFirstFacility`, `goBackToSearchResults`, `downloadFacilities`, `downloadFacilitiesExcel`
+- Download quota UI: lead-in copy, purchase button, tooltips (`expectDownloadLeadIn*`, `expectPurchaseButton*`, `expectOverQuotaPurchaseTooltip`, etc.)
 - Assertions: `expectSearchResults`, `expectNoFacilitiesMessage`, `expectFacilityInResults`, `expectOSIDInResults`, `expectCountryInResults`, `expectDownloadLoginPrompt`
 - Data helpers: `getResultsCount`, `getOSIDFromLocationPage`, `getOSIDFromFacilityPage`
 
@@ -45,7 +46,7 @@ Django admin flows for contributors and download limits.
 
 - Contributor flow: `goToContributors`, `searchContributor`, `clickFirstContributor`, `expectChangeContributorPage`, `expectAdminEmail`
 - Embed config flow: `clearEmbedConfiguration`, `setEmbedLevel`, `setEmbedLevelToDeluxe`, `saveChanges`, `expectEmbedConfigCreated`, `getEmbedConfigValue`, `expectSuccessMessageForContributor`
-- Download-limit flow: `goToDownloadLimits`, `expectDownloadLimitsPage`, `searchUserDownloadLimit`, `clickFirstRowLinkDownloadLimit`, `expectChangeDownloadLimitHeading`, `setFreeDownloadRecords`, `expectSuccessMessageForDownloadLimit`
+- Download-limit flow: `goToDownloadLimits`, `setUserFreeDownloadQuota`, `setFreeDownloadRecords`, `expectSuccessMessageForDownloadLimit`
 
 ### AdminDashboardPage
 Dashboard moderation-queue navigation and access assertions.

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -640,11 +640,11 @@ test("[@smokev1][@smokev2] OSDEV-1813: Smoke: SLC page is opened, user is able t
     locationNameCheck = "Zhejiang Celebrity Finery Co. Ltd";            
   } else if (`${BASE_URL}`.includes("opensupplyhub")) {
     locationAddressCheck =
-      "17th Caiyun Road, Yinan industrial zone";
+      "No. 17, Caiyun Road, Yinan Industrial Park, Fotang Town, Yiwu, Zhejiang, 322002";
     locationNameCheck = "Zhejiang Celebrity Finery Co., Ltd";
   } else if (`${BASE_URL}`.includes("preprod")) {
     locationAddressCheck =
-      "Yinan Industrial Zone, Yiwu";
+      "No. 17, Caiyun Road, Yinan Industrial Park, Fotang Town, Yiwu, Zhejiang, 322002";
     locationNameCheck = "Zhejiang Celebrity Finery Co., Ltd";
   } else {
     locationAddressCheck =

--- a/tests/utils/downloadLimits.ts
+++ b/tests/utils/downloadLimits.ts
@@ -1,0 +1,32 @@
+import { chromium } from "@playwright/test";
+import { AdminPage } from "../pages/AdminPage";
+import { LoginPage } from "../pages/LoginPage";
+
+/** Multi-country filter yielding ~4800 results on test.os-hub.net */
+export const FILTERED_FACILITIES_PATH =
+  "/facilities/?countries=AL&countries=BA&countries=GR&countries=HR&countries=ME&sort_by=contributors_desc";
+
+export const DEFAULT_FREE_DOWNLOAD_QUOTA = "5000";
+
+/**
+ * Sets free_download_records for the test user via Django admin (separate browser).
+ */
+export async function setUserFreeDownloadQuota(freeRecords: string): Promise<void> {
+  const { BASE_URL, USER_EMAIL, USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD } = process.env;
+  if (!BASE_URL || !USER_EMAIL || !USER_ADMIN_EMAIL || !USER_ADMIN_PASSWORD) {
+    throw new Error("Missing env vars for download limit admin setup");
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const loginPage = new LoginPage(page, BASE_URL);
+  const adminPage = new AdminPage(page, BASE_URL);
+
+  await loginPage.loginToAdminPanel(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD);
+  await adminPage.setUserFreeDownloadQuota(USER_EMAIL, freeRecords);
+  await browser.close();
+}
+
+export async function resetUserFreeDownloadQuota(): Promise<void> {
+  await setUserFreeDownloadQuota(DEFAULT_FREE_DOWNLOAD_QUOTA);
+}

--- a/tests/utils/downloadLimits.ts
+++ b/tests/utils/downloadLimits.ts
@@ -1,3 +1,5 @@
+import fs from "fs";
+import path from "path";
 import { chromium } from "@playwright/test";
 import { AdminPage } from "../pages/AdminPage";
 import { LoginPage } from "../pages/LoginPage";
@@ -6,7 +8,27 @@ import { LoginPage } from "../pages/LoginPage";
 export const FILTERED_FACILITIES_PATH =
   "/facilities/?countries=AL&countries=BA&countries=GR&countries=HR&countries=ME&sort_by=contributors_desc";
 
+export const EMBED_CONTRIBUTOR_ID = "661";
+
+export const EMBED_DOWNLOAD_RESULTS_LIMIT = 10000;
+
+export const EMBEDDED_MAP_FIXTURE_PATH = path.resolve(
+  __dirname,
+  "../data/testEM-upto10000.html"
+);
+
 export const DEFAULT_FREE_DOWNLOAD_QUOTA = "5000";
+
+export function getEmbedFacilitiesUrl(baseUrl: string): string {
+  const origin = baseUrl.replace(/\/$/, "");
+  return `${origin}/facilities?contributors=${EMBED_CONTRIBUTOR_ID}&embed=1`;
+}
+
+export function loadEmbeddedMapFixtureHtml(baseUrl: string): string {
+  const html = fs.readFileSync(EMBEDDED_MAP_FIXTURE_PATH, "utf-8");
+  const embedUrl = getEmbedFacilitiesUrl(baseUrl);
+  return html.replace(/<iframe([^>]*)\ssrc="[^"]*"/i, `<iframe$1 src="${embedUrl}"`);
+}
 
 /**
  * Sets free_download_records for the test user via Django admin (separate browser).

--- a/tests/utils/waffleSwitches.ts
+++ b/tests/utils/waffleSwitches.ts
@@ -1,0 +1,30 @@
+import { chromium } from "@playwright/test";
+import { AdminPage } from "../pages/AdminPage";
+import { LoginPage } from "../pages/LoginPage";
+
+export const PRIVATE_INSTANCE_SWITCH_NAME = "private_instance";
+
+/**
+ * Toggles the private_instance waffle switch via Django admin → Switches
+ * (/admin/waffle/switch/), then verifies Active is set as expected.
+ * Tests should reload the main site after enabling (see goToFilteredFacilitiesSearchWithReload).
+ */
+export async function setPrivateInstanceMode(enabled: boolean): Promise<void> {
+  const { BASE_URL, USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD } = process.env;
+  if (!BASE_URL || !USER_ADMIN_EMAIL || !USER_ADMIN_PASSWORD) {
+    throw new Error("Missing env vars for waffle switch admin setup");
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const loginPage = new LoginPage(page, BASE_URL);
+  const adminPage = new AdminPage(page, BASE_URL);
+
+  await loginPage.loginToAdminPanel(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD);
+  await adminPage.setWaffleSwitchActive(PRIVATE_INSTANCE_SWITCH_NAME, enabled);
+  await browser.close();
+}
+
+export async function resetPrivateInstanceMode(): Promise<void> {
+  await setPrivateInstanceMode(false);
+}


### PR DESCRIPTION
## Summary

Adds Playwright regression coverage for **Data Download and Limits** (QAlity), aligned with epic [OSDEV-2192](https://opensupplyhub.atlassian.net/browse/OSDEV-2192).

Tests run **serially** and reset the test user’s free download quota via Django admin before/after scenarios that change quota state.

## Changes

### New: `tests/download-limits.spec.ts`

| Area | Tickets |
|------|---------|
| Anonymous download UX | OSDEV-2069 — login tooltip on hover; login prompt on Excel download |
| Lead-in copy (`DownloadLimitInfo`) | OSDEV-2080, OSDEV-2105, OSDEV-2682 — visibility within/over quota, unfiltered search, anonymous |
| Download button & tooltips | OSDEV-2096, OSDEV-2104 — CSV/Excel menu within quota; purchase CTA and over-quota / exhausted tooltips |
| Purchase CTA | OSDEV-2081 — checkout session POST on “Purchase More Downloads” |
| Download actions | OSDEV-2096 — CSV triggers `/api/facilities-downloads/` with valid `count` |
| Embedded Map | OSDEV-2102  - Data Download Limits: Embedded Map download limits check ,  OSDEV-2109  - The user can... Download a list of facilities with up to 10000 locations in xlsx\csv|
| Private Instance |  OSDEV-1264 - Website user can... Download a list of facilities with up to 10000 locations in xlsx\csv|

All scenarios are tagged `@Regression`.

### New: `tests/utils/downloadLimits.ts`

- `FILTERED_FACILITIES_PATH` — multi-country filter (~4800 results on test.os-hub.net)
- `setUserFreeDownloadQuota` / `resetUserFreeDownloadQuota` — quota setup via Django admin in a separate headless browser

### Page objects

- **MainPage** — filtered/unfiltered search, download menu (CSV/Excel), purchase button, lead-in copy, quota tooltips
- **AdminPage** — `setUserFreeDownloadQuota` helper
- **LoginPage** — `loginViaAuthPage` for `/auth/login`; shared cookie handling via `BasePage`
- **BasePage** — `acceptCookiesIfPresent`
- **README** — documents new methods

## Prerequisites

Requires env vars (same as other admin-backed tests):

- `BASE_URL`, `USER_EMAIL`, `USER_PASSWORD`
- `USER_ADMIN_EMAIL`, `USER_ADMIN_PASSWORD`

## Test plan

- [ ] `npx playwright test tests/download-limits.spec.ts`
- [ ] Confirm test user quota is restored to 5000 after the suite (`afterAll` reset)
- [ ] `npx playwright test --grep "@Regression"`
- [ ] Smoke/admin download-limit steps still pass (existing flow unchanged; extended via `setUserFreeDownloadQuota`)

## Notes

- Suite uses `test.describe.configure({ mode: "serial" })` because quota is shared test state.
- CSV download test uses extended timeouts (90s API wait / 120s test timeout).
- Purchase test asserts a checkout-related POST (URL contains `checkout`, `stripe`, or `session`) without validating redirect URL.