### PR TITLE
Docs: replace remaining docker-compose with docker compose in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ This project includes Docker configuration for easy setup and consistent testing
    docker compose exec e2e-tests npm run test
 
    # Run smoke by tag (same as locally)
-   docker-compose exec e2e-tests npx playwright test --grep "@smokev1"
-   docker-compose exec e2e-tests npx playwright test --grep "@smokev2"
-   docker-compose exec e2e-tests npx playwright test --grep "@regression"
+   docker compose exec e2e-tests npx playwright test --grep "@smokev1"
+   docker compose exec e2e-tests npx playwright test --grep "@smokev2"
+   docker compose exec e2e-tests npx playwright test --grep "@regression"
    ```
 
 4. **Access test reports:**


### PR DESCRIPTION
## Summary

- Replaces 3 remaining `docker-compose` occurrences with `docker compose` in the smoke/regression run examples in `README.md`

This update is important because `docker-compose` (V1) was deprecated and removed in newer Docker versions, so using the `docker compose` plugin syntax ensures the documented commands work on all current and future Docker installations.

## Test plan

- [ ] Verify no `docker-compose` references remain in README files